### PR TITLE
Deduplicate common code

### DIFF
--- a/lib/manageiq/api/common/application_controller_mixins/request_path.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_path.rb
@@ -8,7 +8,7 @@ module ManageIQ
           end
 
           def request_path_parts
-            @request_path_parts ||= request_path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)(\/(?<primary_collection_id>\d+)(\/(?<subcollection_name>\w+))?)?/)&.named_captures || {}
+            @request_path_parts ||= request_path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)(\/(?<primary_collection_id>[^\/]+)(\/(?<subcollection_name>\w+))?)?/)&.named_captures || {}
           end
 
           def subcollection?

--- a/spec/lib/manageiq/api/common/application_controller_mixins/request_path_spec.rb
+++ b/spec/lib/manageiq/api/common/application_controller_mixins/request_path_spec.rb
@@ -27,29 +27,29 @@ describe ManageIQ::API::Common::ApplicationControllerMixins::RequestPath do
       expect(test_class.new("/v1.0/primary/1/").subcollection?).to      eq(false)
       expect(test_class.new("/v1.0/primary/1/sub").subcollection?).to   eq(true)
       expect(test_class.new("/v1.0/primary/1/sub/").subcollection?).to  eq(true)
+      expect(test_class.new("/v1.0/primary/a_b/sub").subcollection?).to eq(true)
     end
 
     it "invalid paths" do
-      expect(test_class.new("/v1.0/primary/abc/sub").subcollection?).to eq(false)
-      expect(test_class.new("/primary/abc/sub").subcollection?).to      eq(false)
+      expect(test_class.new("/primary/abc/sub").subcollection?).to eq(false)
     end
   end
 
   context "#request_path_parts" do
     it "valid paths" do
-      expect(test_class.new("/aaa/bbb/v1.0/primary").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => nil, "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/aaa/v1.0/primary").request_path_parts).to     eq("full_version_string" => "v1.0", "primary_collection_id" => nil, "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary").request_path_parts).to         eq("full_version_string" => "v1.0", "primary_collection_id" => nil, "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/").request_path_parts).to        eq("full_version_string" => "v1.0", "primary_collection_id" => nil, "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1").request_path_parts).to       eq("full_version_string" => "v1.0", "primary_collection_id" => "1", "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1/").request_path_parts).to      eq("full_version_string" => "v1.0", "primary_collection_id" => "1", "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1/sub").request_path_parts).to   eq("full_version_string" => "v1.0", "primary_collection_id" => "1", "primary_collection_name" => "primary", "subcollection_name" => "sub")
-      expect(test_class.new("/v1.0/primary/1/sub/").request_path_parts).to  eq("full_version_string" => "v1.0", "primary_collection_id" => "1", "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/aaa/bbb/v1.0/primary").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/aaa/v1.0/primary").request_path_parts).to     eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary").request_path_parts).to         eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/").request_path_parts).to        eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1").request_path_parts).to       eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1/").request_path_parts).to      eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1/sub").request_path_parts).to   eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/v1.0/primary/1/sub/").request_path_parts).to  eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/v1.0/primary/a_b/sub").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => "a_b", "primary_collection_name" => "primary", "subcollection_name" => "sub")
     end
 
     it "invalid paths" do
-      expect(test_class.new("/v1.0/primary/abc/sub").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => nil, "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/primary/1/sub").request_path_parts).to        eq({})
+      expect(test_class.new("/primary/1/sub").request_path_parts).to eq({})
     end
   end
 end


### PR DESCRIPTION
- Extract common request path methods from sources-api and topological_inventory-api to a shared module
- Add tests for `#subcollection?` and `#request_path_parts`
- Fix inconsistencies between the two applications

Related to TPINVTRY-170