### PR TITLE
Add check for readOnly parameters in `params_for_create`

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/insights/api/common/application_controller_mixins/request_body_validation.rb
@@ -20,7 +20,7 @@ module Insights
             @body_params ||= begin
               raw_body    = request.body.read
               parsed_body = raw_body.blank? ? {} : JSON.parse(raw_body)
-              ActionController::Parameters.new(parsed_body).permit!
+              ActionController::Parameters.new(parsed_body)
             rescue JSON::ParserError
               raise Insights::API::Common::ApplicationControllerMixins::RequestBodyValidation::BodyParseError, "Failed to parse request body, expected JSON"
             end

--- a/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
@@ -27,6 +27,18 @@ module Api
           klass = request_path_parts["primary_collection_name"].singularize.camelize.safe_constantize
           klass.find(request_path_parts["primary_collection_id"].to_i)
         end
+
+        def api_version
+          @api_version ||= name.split("::")[1].downcase.delete("v").sub("x", ".")
+        end
+
+        def model_name
+          @model_name ||= controller_name.classify
+        end
+
+        def name
+          self.class.to_s
+        end
       end
     end
   end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -45,6 +45,20 @@ module Api
       end
     end
 
+    class UsersController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+
+      def create
+        params_for_create(:writeable => true)
+        render :json => "OK".to_json
+      end
+
+      def update
+        params_for_update
+        render :json => "OK".to_json
+      end
+    end
+
     class ExtrasController < ApplicationController
       self.openapi_enabled = false
 

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  include TenancyConcern
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       resources :sources, :only => [:index]
       resources :source_types, :only => [:index]
       resources :extras, :only => [:index]
+      resources :users, :only => [:create, :update]
     end
 
     namespace :v0x1, :path => "v0.1" do

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -567,6 +567,36 @@
         }
       }
     },
+    "/users": {
+      "post":{    
+        "summary": "Create a new User object with only writeable params",
+        "operationId": "createUserWriteable",
+        "description": "Creates a User object with only writeable params",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUser"
+              }
+            }
+          },
+          "description": "Attributes to create a User object",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "User Object creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/graphql": {
       "post": {
         "summary": "Perform a GraphQL Query",
@@ -1075,6 +1105,21 @@
           }
         }
       },
+      "User": {
+        "properties": {
+          "name": {
+            "example": "fred",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "active": {
+            "type": "string",
+            "readOnly": true
+          }
+        }
+      },
       "PersonsCollection": {
         "type": "object",
         "properties": {
@@ -1089,6 +1134,14 @@
             "items": {
               "$ref": "#/components/schemas/Person"
             }
+          }
+        }
+      },
+      "CreateUser": {
+        "type": "object",
+        "properties": {
+          "reference_number": {
+            "type": "string"
           }
         }
       }

--- a/spec/requests/params_spec.rb
+++ b/spec/requests/params_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe "Insights::API::Common::ApplicationController Parameters", :type 
     end
   end
 
+  context "POST with writeonly set" do
+    it "readOnly parameters fail" do
+      body = { "active" => "yes" }
+      post("/api/v1.0/users?writeonly=true", :headers => headers, :params => body)
+      expect(response.status).to eq(400)
+    end
+
+    it "looks up requestBody schema parameters" do
+      body = { "reference_number" => "123" }
+      post("/api/v1.0/users?writeonly=true", :headers => headers, :params => body)
+      expect(response.status).to eq(200)
+    end
+  end
+
   context "PATCH" do
     it "valid parameters" do
       body = { 'name' => 'fred', 'zip' => '07825', 'age' => 45 }
@@ -52,6 +66,12 @@ RSpec.describe "Insights::API::Common::ApplicationController Parameters", :type 
       body = { 'name' => 'fred', 'zip' => '07825', 'age' => 45, 'nested' => {'props' => 'abcd'} }
       patch("/api/v1.0/persons/10", :headers => headers, :params => body)
       expect(response.status).to eq(200)
+    end
+
+    it "readOnly parameters fail" do
+      body = { "active" => "yes" }
+      patch("/api/v1.0/users/10", :headers => headers, :params => body)
+      expect(response.status).to eq(400)
     end
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-927

Found a bug when investigating this, basically in the `params_for_create` method before we were just allowing all the fields to come through whether they were readOnly or not. `params_for_update` did the right thing, but `params_for_create` was a bit more complicated since the requstBody can come in as a different ref with different fields.

This PR enhances the `params_for_create` function in the ParameterMixin so that it checks for any readOnly parameters as well as the requestBody schema if passing in `:writeable => true` when calling `params_for_create`.