### PR TITLE
Use add_role_to_group during seeding

### DIFF
--- a/lib/insights/api/common/rbac/seed.rb
+++ b/lib/insights/api/common/rbac/seed.rb
@@ -12,9 +12,14 @@ module Insights
 
           def process
             Insights::API::Common::Request.with_request(@request) do
-              create_groups
-              create_roles
-              create_policies
+              begin
+                create_groups
+                create_roles
+                add_roles_to_groups
+              rescue RBACApiClient::ApiError => e
+                Rails.logger.error("Exception when RBACApiClient::ApiError : #{e}")
+                raise
+              end
             end
           end
 
@@ -24,20 +29,14 @@ module Insights
             current = current_groups
             names = current.collect(&:name)
             group = RBACApiClient::Group.new
-            begin
-              Service.call(RBACApiClient::GroupApi) do |api_instance|
-                @acl_data['groups'].each do |grp|
-                  next if names.include?(grp['name'])
+            Service.call(RBACApiClient::GroupApi) do |api_instance|
+              @acl_data['groups'].each do |grp|
+                next if names.include?(grp['name'])
 
-                  Rails.logger.info("Creating #{grp['name']}")
-                  group.name = grp['name']
-                  group.description = grp['description']
-                  api_instance.create_group(group)
-                end
+                group.name = grp['name']
+                group.description = grp['description']
+                api_instance.create_group(group)
               end
-            rescue RBACApiClient::ApiError => e
-              Rails.logger.error("Exception when calling GroupApi->create_group: #{e}")
-              raise
             end
           end
 
@@ -51,25 +50,20 @@ module Insights
             current = current_roles
             names = current.collect(&:name)
             role_in = RBACApiClient::RoleIn.new
-            begin
-              Service.call(RBACApiClient::RoleApi) do |api_instance|
-                @acl_data['roles'].each do |role|
-                  next if names.include?(role['name'])
+            Service.call(RBACApiClient::RoleApi) do |api_instance|
+              @acl_data['roles'].each do |role|
+                next if names.include?(role['name'])
 
-                  role_in.name = role['name']
-                  role_in.access = []
-                  role['access'].each do |obj|
-                    access = RBACApiClient::Access.new
-                    access.permission = obj['permission']
-                    access.resource_definitions = create_rds(obj)
-                    role_in.access << access
-                  end
-                  api_instance.create_roles(role_in)
+                role_in.name = role['name']
+                role_in.access = []
+                role['access'].each do |obj|
+                  access = RBACApiClient::Access.new
+                  access.permission = obj['permission']
+                  access.resource_definitions = create_rds(obj)
+                  role_in.access << access
                 end
+                api_instance.create_roles(role_in)
               end
-            rescue RBACApiClient::ApiError => e
-              Rails.logger.error("Exception when calling RoleApi->create_roles: #{e}")
-              raise
             end
           end
 
@@ -85,38 +79,35 @@ module Insights
             end
           end
 
+          def add_new_role_to_group(api_instance, group_uuid, role_uuid)
+            role_in = RBACApiClient::GroupRoleIn.new
+            role_in.roles = [role_uuid]
+            api_instance.add_role_to_group(group_uuid, role_in)
+          end
+
+          def role_exists_in_group?(api_instance, group_uuid, role_uuid)
+            api_instance.list_roles_for_group(group_uuid).any? do |role|
+              role.uuid == role_uuid
+            end
+          end
+
           def current_roles
             Service.call(RBACApiClient::RoleApi) do |api|
               Service.paginate(api, :list_roles, {}).to_a
             end
           end
 
-          def create_policies
-            names = current_policies.collect(&:name)
+          def add_roles_to_groups
             groups = current_groups
             roles = current_roles
-            policy_in = RBACApiClient::PolicyIn.new
-            begin
-              Service.call(RBACApiClient::PolicyApi) do |api_instance|
-                @acl_data['policies'].each do |policy|
-                  next if names.include?(policy['name'])
+            Service.call(RBACApiClient::GroupApi) do |api_instance|
+              @acl_data['policies'].each do |link|
+                group_uuid = find_uuid('Group', groups, link['group']['name'])
+                role_uuid = find_uuid('Role', roles, link['role']['name'])
+                next if role_exists_in_group?(api_instance, group_uuid, role_uuid)
 
-                  policy_in.name = policy['name']
-                  policy_in.description = policy['description']
-                  policy_in.group = find_uuid('Group', groups, policy['group']['name'])
-                  policy_in.roles = [find_uuid('Role', roles, policy['role']['name'])]
-                  api_instance.create_policies(policy_in)
-                end
+                add_new_role_to_group(api_instance, group_uuid, role_uuid)
               end
-            rescue RBACApiClient::ApiError => e
-              Rails.logger.error("Exception when calling PolicyApi->create_policies: #{e}")
-              raise
-            end
-          end
-
-          def current_policies
-            Service.call(RBACApiClient::PolicyApi) do |api|
-              Service.paginate(api, :list_policies, {}).to_a
             end
           end
 

--- a/spec/data/test_seed.yml
+++ b/spec/data/test_seed.yml
@@ -1,0 +1,29 @@
+---
+resource_definition1: &test_rd
+  attribute_filter:
+    value: '99'
+    key: id
+    operator: equal
+access1: &test_access1
+  permission: catalog:portfolios:read
+  resource_definitions:
+          - *test_rd
+role1: &TestRole
+  name: Test Role
+  description: A test role
+  access:
+    - *test_access1
+group1: &TestGroup
+  name: Test Group
+  description: A test group
+policy1: &TestPolicy
+  name: Test Policy
+  group: *TestGroup
+  role: *TestRole
+  description: A test policy
+roles:
+  - *TestRole
+groups:
+  - *TestGroup
+policies:
+  - *TestPolicy

--- a/spec/data/user.yml
+++ b/spec/data/user.yml
@@ -1,0 +1,17 @@
+---
+identity:
+  account_number: '1111111'
+  type: User
+  user:
+    username: johndoe
+    email: johndoe@example.com
+    first_name: John
+    last_name: Doe
+    is_active: true
+    is_org_admin: false
+    is_internal: false
+    locale: en_US
+  internal:
+    org_id: '1111111'
+    auth_type: basic-auth
+    auth_time: 6300

--- a/spec/lib/insights/api/common/rbac/seed_spec.rb
+++ b/spec/lib/insights/api/common/rbac/seed_spec.rb
@@ -1,0 +1,84 @@
+describe Insights::API::Common::RBAC::Seed do
+  include_context "rbac_seed_objects"
+  let(:seed_file) { File.join('.', 'spec/data/test_seed.yml') }
+  let(:user_file) { File.join('.', 'spec/data/user.yml') }
+  let(:subject) { described_class.new(seed_file, user_file) }
+  let(:request) { nil }
+
+  shared_examples_for "#process" do
+    context "nothing exists" do
+      before do
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return([], [group1])
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, {}).and_return([], [role1])
+
+        allow(api_instance).to receive(:create_roles).and_return(role1)
+        allow(api_instance).to receive(:create_group).and_return(group1)
+        allow(RBACApiClient::GroupRoleIn).to receive(:new).and_return(role1_in)
+      end
+
+      it "makes an API request to #list_roles_for_group to return empty roles" do
+        Insights::API::Common::Request.with_request(request) do
+          expect(api_instance).to receive(:add_role_to_group).with(group1.uuid, role1_in).and_return([role1_detail])
+          expect(api_instance).to receive(:list_roles_for_group).with(group1.uuid).and_return([])
+
+          subject.process
+        end
+      end
+    end
+
+    context "all data exists" do
+      before do
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, {}).and_return(roles)
+        allow(api_instance).to receive(:create_roles).and_return(role1)
+      end
+
+      it "makes an API request to #list_roles_for_group to return the correct role" do
+        Insights::API::Common::Request.with_request(request) do
+          expect(api_instance).to receive(:list_roles_for_group).with(group1.uuid).and_return([role1_detail])
+
+          subject.process
+        end
+      end
+    end
+  end
+
+  context "#process" do
+    before do
+      allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
+      allow(rs_class).to receive(:call).with(RBACApiClient::RoleApi).and_yield(api_instance)
+    end
+
+    context "no request" do
+      let(:user_file) { File.join('.', 'spec/data/user.yml') }
+      let(:request) { nil }
+
+      it_behaves_like "#process"
+    end
+
+    context "with_request" do
+      let(:user_file) { nil }
+      let(:request) { default_request }
+
+      it_behaves_like "#process"
+    end
+
+    context "no user file" do
+      let(:user_file) { File.join('.', 'does_not_exist') }
+      let(:request) { nil }
+      it "raises an exception" do
+        expect { subject.process }.to raise_exception(RuntimeError, /not found/)
+      end
+    end
+
+    context "api_error" do
+      let(:user_file) { File.join('.', 'spec/data/user.yml') }
+      let(:request) { nil }
+
+      it "raises an exception" do
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_raise(RBACApiClient::ApiError.new('Kaboom'))
+        expect { subject.process }.to raise_exception(RBACApiClient::ApiError, /Kaboom/)
+      end
+    end
+  end
+end

--- a/spec/lib/insights/api/common/rbac/seed_spec.rb
+++ b/spec/lib/insights/api/common/rbac/seed_spec.rb
@@ -76,7 +76,7 @@ describe Insights::API::Common::RBAC::Seed do
       let(:request) { nil }
 
       it "raises an exception" do
-        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_raise(RBACApiClient::ApiError.new('Kaboom'))
+        allow(Insights::API::Common::RBAC::Service).to receive(:paginate).and_raise(RBACApiClient::ApiError.new(:message => 'Kaboom'))
         expect { subject.process }.to raise_exception(RBACApiClient::ApiError, /Kaboom/)
       end
     end

--- a/spec/support/rbac_seed_context.rb
+++ b/spec/support/rbac_seed_context.rb
@@ -1,0 +1,17 @@
+RSpec.shared_context "rbac_seed_objects" do
+  let(:app_name) { 'catalog' }
+  let(:resource) { "portfolios" }
+  let(:group1) { instance_double(RBACApiClient::GroupOut, :name => 'Test Group', :uuid => "123") }
+  let(:role1) { instance_double(RBACApiClient::RoleOut, :name => "Test Role", :uuid => "67899") }
+  let(:role1_in) { RBACApiClient::GroupRoleIn.new }
+
+  let(:role1_detail) { instance_double(RBACApiClient::RoleWithAccess, :name => role1.name, :uuid => role1.uuid, :access => [access1]) }
+  let(:groups) { [group1] }
+  let(:roles) { [role1] }
+  let(:filter1) { instance_double(RBACApiClient::ResourceDefinitionFilter, :key => 'id', :operation => 'equal', :value => "99") }
+  let(:resource_def1) { instance_double(RBACApiClient::ResourceDefinition, :attribute_filter => filter1) }
+  let(:access1) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:read", :resource_definitions => [resource_def1]) }
+  let(:group_uuids) { [group1.uuid] }
+  let(:api_instance) { double }
+  let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
+end


### PR DESCRIPTION
This PR contains just the seeding portion of this PR https://github.com/RedHatInsights/insights-api-common-rails/pull/137 which has been closed.
Instead of adding roles to group via Policies now we can directly add role to a group