### PR TITLE
[WIP] Enhancing sort_by to support sorting on association attributes and count

### DIFF
--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -100,7 +100,7 @@ module Insights
               "SortByAttribute"    => {
                 "type"        => "string",
                 "description" => "Attribute with optional order to sort the result set by.",
-                "pattern"     => "^[a-z\\-_]+(:asc|:desc)?$"
+                "pattern"     => "^[a-z\\-_\\.@]+(:asc|:desc)?$"
               }
             }
           end

--- a/lib/insights/api/common/paginated_response.rb
+++ b/lib/insights/api/common/paginated_response.rb
@@ -17,7 +17,7 @@ module Insights
             res = @base_query.order(:id).limit(limit).offset(offset)
             sort_by_association.collect do |selection|
               association = selection.split('.').first
-              res = res.joins(association.to_sym)
+              res = res.left_outer_joins(association.to_sym)
             end
             order_options = sort_by_options(res.klass)
             res = res.reorder(order_options) if order_options.present?

--- a/lib/insights/api/common/paginated_response.rb
+++ b/lib/insights/api/common/paginated_response.rb
@@ -15,10 +15,8 @@ module Insights
         def records
           @records ||= begin
             res = @base_query.order(:id).limit(limit).offset(offset)
-            sort_by_association.collect do |selection|
-              association = selection.split('.').first
-              res = res.left_outer_joins(association.to_sym)
-            end
+            associations = sort_by_association.collect { |selection| selection.split('.').first.to_sym }.uniq
+            res = res.left_outer_joins(*associations) if associations.present?
             order_options = sort_by_options(res.klass)
             res = res.reorder(order_options) if order_options.present?
             sort_by_association.each do |selection|

--- a/lib/insights/api/common/paginated_response.rb
+++ b/lib/insights/api/common/paginated_response.rb
@@ -2,7 +2,7 @@ module Insights
   module API
     module Common
       class PaginatedResponse
-        ASSOCIATION_COUNT_ATTR = "count".freeze
+        ASSOCIATION_COUNT_ATTR = "@count".freeze
 
         attr_reader :limit, :offset, :sort_by
 

--- a/lib/insights/api/common/paginated_response.rb
+++ b/lib/insights/api/common/paginated_response.rb
@@ -103,10 +103,10 @@ module Insights
                 association, sort_attr = sort_attr.split('.')
                 association_class = association.classify.constantize
                 arel = if sort_attr == ASSOCIATION_COUNT_ATTR
-                  Arel.sql("COUNT (#{association_class.table_name})")
-                else
-                  association_class.arel_attribute(sort_attr)
-                end
+                         Arel.sql("COUNT (#{association_class.table_name})")
+                       else
+                         association_class.arel_attribute(sort_attr)
+                       end
               else
                 arel = model.arel_attribute(sort_attr)
               end
@@ -136,12 +136,10 @@ module Insights
               next unless sort_attr.include?('.')
 
               association, attr = sort_attr.split('.')
-              if attr == ASSOCIATION_COUNT_ATTR
-                group_attrs << @base_query.arel_attribute(:id) if group_attrs.empty?
+              next unless attr == ASSOCIATION_COUNT_ATTR
 
-                association_class = association.classify.constantize
-                group_attrs << association_class.arel_attribute(:id)
-              end
+              group_attrs << @base_query.arel_attribute(:id) if group_attrs.empty?
+              group_attrs << association.classify.constantize.arel_attribute(:id)
             end
             group_attrs.compact.uniq
           end

--- a/spec/dummy/app/controllers/api/v1/application_types_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/application_types_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ApplicationTypesController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1/applications_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/applications_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ApplicationsController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -68,8 +68,10 @@ module Api
       end
     end
 
-    class GraphqlController < Api::V1::GraphqlController; end
-    class SourcesController < Api::V1::SourcesController; end
-    class SourceTypesController < Api::V1::SourceTypesController; end
+    class GraphqlController           < Api::V1::GraphqlController; end
+    class ApplicationsController      < Api::V1::ApplicationsController; end
+    class ApplicationTypesController  < Api::V1::ApplicationTypesController; end
+    class SourcesController           < Api::V1::SourcesController; end
+    class SourceTypesController       < Api::V1::SourceTypesController; end
   end
 end

--- a/spec/dummy/app/models/application.rb
+++ b/spec/dummy/app/models/application.rb
@@ -1,0 +1,8 @@
+class Application < ApplicationRecord
+  include TenancyConcern
+  belongs_to :source
+  belongs_to :application_type
+
+  attribute :availability_status, :string
+  validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
+end

--- a/spec/dummy/app/models/application.rb
+++ b/spec/dummy/app/models/application.rb
@@ -4,5 +4,5 @@ class Application < ApplicationRecord
   belongs_to :application_type
 
   attribute :availability_status, :string
-  validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
+  validates :availability_status, :inclusion => {:in => %w[available unavailable]}, :allow_nil => true
 end

--- a/spec/dummy/app/models/application_type.rb
+++ b/spec/dummy/app/models/application_type.rb
@@ -1,0 +1,4 @@
+class ApplicationType < ApplicationRecord
+  has_many :applications
+  has_many :sources, :through => :applications
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       get "/error_nested", :to => "errors#error_nested"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
+      resources :applications, :only => [:index]
+      resources :application_types, :only => [:index]
       resources :authentications, :only => [:create, :update]
       resources :vms, :only => [:index, :show]
       resources :persons, :only => [:index, :create, :show, :update]

--- a/spec/dummy/db/migrate/20200121140744_add_applications_and_application_types.rb
+++ b/spec/dummy/db/migrate/20200121140744_add_applications_and_application_types.rb
@@ -1,0 +1,19 @@
+class AddApplicationsAndApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :application_types do |t|
+      t.string :name, :null => false
+      t.string :display_name
+      t.index %w[name], :unique => true
+      t.timestamps
+    end
+
+    create_table :applications do |t|
+      t.string :availability_status
+      t.string :availability_status_error
+      t.references :tenant,           :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :source,           :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :application_type, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -1259,7 +1259,7 @@
       "SortByAttribute": {
         "type": "string",
         "description": "Attribute with optional order to sort the result set by.",
-        "pattern": "^[a-z\\-_]+(:asc|:desc)?$"
+        "pattern": "^[a-z\\-_\\.]+(:asc|:desc)?$"
       },
       "Source": {
         "type": "object",

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -1259,7 +1259,7 @@
       "SortByAttribute": {
         "type": "string",
         "description": "Attribute with optional order to sort the result set by.",
-        "pattern": "^[a-z\\-_\\.]+(:asc|:desc)?$"
+        "pattern": "^[a-z\\-_\\.@]+(:asc|:desc)?$"
       },
       "Source": {
         "type": "object",

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -20,6 +20,140 @@
     }
   ],
   "paths": {
+    "/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes",
+        "operationId": "listApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types/{id}": {
+      "get": {
+        "summary": "Show an existing ApplicationType",
+        "operationId": "showApplicationType",
+        "description": "Returns a ApplicationType object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationType info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationType"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications": {
+      "get": {
+        "summary": "List Applications",
+        "operationId": "listApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "summary": "Show an existing Application",
+        "operationId": "showApplication",
+        "description": "Returns a Application object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Application info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Application"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/authentications": {
       "get": {
         "summary": "List Authentications",
@@ -407,6 +541,98 @@
         }
       }
     },
+    "/sources/{id}/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes for Source",
+        "operationId": "listSourceApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/applications": {
+      "get": {
+        "summary": "List Applications for Source",
+        "operationId": "listSourceApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sources/{id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",
@@ -697,6 +923,109 @@
       }
     },
     "schemas": {
+      "Application": {
+        "type": "object",
+        "properties": {
+          "application_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant": {
+            "type": "string",
+            "readOnly": true
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            }
+          }
+        }
+      },
+      "ApplicationType": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },   
+          "dependent_applications": {
+            "type": "object"
+          },   
+          "display_name": {
+            "type": "string"
+          },   
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },   
+          "name": {
+            "type": "string"
+          },   
+          "supported_authentication_types": {
+            "type": "object"
+          },   
+          "supported_source_types": {
+            "type": "object"
+          },   
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }    
+        },   
+        "additionalProperties": false
+      },   
+      "ApplicationTypesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },   
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },   
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationType"
+            }    
+          }    
+        }    
+      }, 
       "Authentication": {
         "additionalProperties": false,
         "type": "object",

--- a/spec/requests/api/graphql_spec.rb
+++ b/spec/requests/api/graphql_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     it "sorting with an association attribute and direct attribute in mixed order" do
       Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
       Application.create(:application_type => catalog_apptype, :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
@@ -374,13 +374,13 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
             {
               "name": "source_b3",
               "application_types": [
+                { "display_name": "Cost Management" }
               ]
             },
             {
               "name": "source_b2",
               "application_types": [
-                { "display_name": "Catalog" },
-                { "display_name": "Cost Management" }
+                { "display_name": "Catalog" }
               ]
             },
             {
@@ -400,7 +400,7 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: ["application_types.@count", "application_types.display_name"]) {
+          sources(filter: { name: { starts_with: "source_b"}}, sort_by: ["application_types.@count", "name"]) {
             name
             application_types {
               display_name

--- a/spec/requests/api/graphql_spec.rb
+++ b/spec/requests/api/graphql_spec.rb
@@ -371,7 +371,7 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
       expect(response.parsed_body["data"]).to eq(JSON.parse('
         {
           "sources": [
-            { 
+            {
               "name": "source_b3",
               "application_types": [
               ]

--- a/spec/requests/api/graphql_spec.rb
+++ b/spec/requests/api/graphql_spec.rb
@@ -268,16 +268,22 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
   end
 
   context "supports sort_by with association attributes" do
-    before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
+    before do
+      stub_const("ENV", "BYPASS_TENANCY" => nil)
+
+      @source_s1 = Source.create!(:tenant => tenant, :name => "source_s1", :source_type => source_typeR)
+      @source_s2 = Source.create!(:tenant => tenant, :name => "source_s2", :source_type => source_typeR)
+      @source_s3 = Source.create!(:tenant => tenant, :name => "source_s3", :source_type => source_typeR)
+    end
 
     it "sorting with an association attribute" do
-      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype,    :source => source_b3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: "application_types.display_name") {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: "application_types.display_name") {
             name
             application_types {
               display_name
@@ -290,19 +296,19 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
         {
           "sources": [
             {
-              "name": "source_b1",
+              "name": "source_s1",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
             },
             {
-              "name": "source_b2",
+              "name": "source_s2",
               "application_types": [
                 { "display_name": "Cost Management" }
               ]
             },
             {
-              "name": "source_b3",
+              "name": "source_s3",
               "application_types": [
                 { "display_name": "Topological Inventory" }
               ]
@@ -312,13 +318,13 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting with an association attribute in descending order" do
-      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype,    :source => source_b3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: "application_types.display_name:desc") {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: "application_types.display_name:desc") {
             name
             application_types {
               display_name
@@ -331,19 +337,19 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
         {
           "sources": [
             {
-              "name": "source_b3",
+              "name": "source_s3",
               "application_types": [
                 { "display_name": "Topological Inventory" }
               ]
             },
             {
-              "name": "source_b2",
+              "name": "source_s2",
               "application_types": [
                 { "display_name": "Cost Management" }
               ]
             },
             {
-              "name": "source_b1",
+              "name": "source_s1",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
@@ -353,13 +359,13 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting with an association attribute and direct attribute in mixed order" do
-      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => catalog_apptype, :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: ["name:desc", "application_types.display_name:asc"]) {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["name:desc", "application_types.display_name:asc"]) {
             name
             application_types {
               display_name
@@ -372,19 +378,19 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
         {
           "sources": [
             {
-              "name": "source_b3",
+              "name": "source_s3",
               "application_types": [
                 { "display_name": "Cost Management" }
               ]
             },
             {
-              "name": "source_b2",
+              "name": "source_s2",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
             },
             {
-              "name": "source_b1",
+              "name": "source_s1",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
@@ -394,13 +400,13 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting based on an association count" do
-      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: ["application_types.@count", "name"]) {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["application_types.@count", "name"]) {
             name
             application_types {
               display_name
@@ -413,18 +419,162 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
         {
           "sources": [
             {
-              "name": "source_b3",
+              "name": "source_s3",
               "application_types": [
               ]
             },
             {
-              "name": "source_b1",
+              "name": "source_s1",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
             },
             {
-              "name": "source_b2",
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count with secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["application_types.@count", "name"]) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count with descending secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["application_types.@count", "name:desc"]) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count with secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["application_types.@count", "name"]) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
               "application_types": [
                 { "display_name": "Cost Management" },
                 { "display_name": "Topological Inventory" }
@@ -435,13 +585,13 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting based on an association count in reverse order" do
-      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
-          sources(filter: { name: { starts_with: "source_b"}}, sort_by: "application_types.@count:desc") {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: "application_types.@count:desc") {
             name
             application_types {
               display_name
@@ -454,20 +604,72 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
         {
           "sources": [
             {
-              "name": "source_b2",
+              "name": "source_s2",
               "application_types": [
                 { "display_name": "Cost Management" },
                 { "display_name": "Topological Inventory" }
               ]
             },
             {
-              "name": "source_b1",
+              "name": "source_s1",
               "application_types": [
                 { "display_name": "Catalog" }
               ]
             },
             {
-              "name": "source_b3",
+              "name": "source_s3",
+              "application_types": [
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count in reverse order with secondary attribute in descending order" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s4, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: ["application_types.@count:desc", "name:desc"]) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Catalog" },
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s1",
               "application_types": [
               ]
             }

--- a/spec/requests/api/graphql_spec.rb
+++ b/spec/requests/api/graphql_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
   let!(:auth_b221)    { Authentication.create!(:tenant => tenant, :resource => endpoint_b22, :authtype => "userpassword", :username => "admin", :password => "secret") }
   let!(:auth_b222)    { Authentication.create!(:tenant => tenant, :resource => endpoint_b22, :authtype => "token") }
 
+  let!(:catalog_apptype) { ApplicationType.create(:name => "/insights/platform/catalog", :display_name => "Catalog") }
+  let!(:cost_apptype)    { ApplicationType.create(:name => "/insights/platform/cost-management", :display_name => "Cost Management") }
+  let!(:topo_apptype)    { ApplicationType.create(:name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory") }
+
   context "querying sources" do
     before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
 
@@ -264,18 +268,12 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
   end
 
   context "supports sort_by with association attributes" do
-    before {
-      stub_const("ENV", "BYPASS_TENANCY" => nil)
-
-      @catalog_at  = ApplicationType.create(:name => "/insights/platform/catalog", :display_name => "Catalog")
-      @cost_at     = ApplicationType.create(:name => "/insights/platform/cost-management", :display_name => "Cost Management")
-      @topo_at     = ApplicationType.create(:name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory")
-    }
+    before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
 
     it "sorting with an association attribute" do
-      Application.create(:application_type => @catalog_at, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => @cost_at,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => @topo_at,    :source => source_b3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => source_b3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
@@ -314,9 +312,9 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting with an association attribute in descending order" do
-      Application.create(:application_type => @catalog_at, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => @cost_at,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => @topo_at,    :source => source_b3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => source_b3, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
@@ -355,9 +353,9 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting with an association attribute and direct attribute in mixed order" do
-      Application.create(:application_type => @catalog_at, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => @catalog_at, :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => @cost_at,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
@@ -396,9 +394,9 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting based on an association count" do
-      Application.create(:application_type => @catalog_at, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => @cost_at,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => @topo_at,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => source_b2, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {
@@ -437,9 +435,9 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
     end
 
     it "sorting based on an association count in reverse order" do
-      Application.create(:application_type => @catalog_at, :source => source_b1, :tenant => tenant)
-      Application.create(:application_type => @cost_at,    :source => source_b2, :tenant => tenant)
-      Application.create(:application_type => @topo_at,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => source_b1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => source_b2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => source_b2, :tenant => tenant)
 
       post(graphql_endpoint, :headers => headers, :params => {"query" => '
         {

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     end
   end
 
-  context "sorted results via sort_by against association attributes" do
+  context "sorted results via sort_by against associations" do
     before do
       @source_s1 = Source.create!(:tenant => tenant, :name => "source_s1", :source_type => source_type)
       @source_s2 = Source.create!(:tenant => tenant, :name => "source_s2", :source_type => source_type)
@@ -171,33 +171,33 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     end
 
     it "succeeds with single association attribute in ascending order" do
-      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
       Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
 
       expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by=application_types.display_name",
                                      [
-                                       {:name => "source_s1"},
                                        {:name => "source_s2"},
+                                       {:name => "source_s1"},
                                        {:name => "source_s3"}
                                      ])
     end
 
     it "succeeds with single association attribute in descending order" do
       Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
 
       expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by=application_types.display_name:desc",
                                      [
-                                       {:name => "source_s3"},
                                        {:name => "source_s2"},
+                                       {:name => "source_s3"},
                                        {:name => "source_s1"}
                                      ])
     end
 
     it "succeeds with an association attribute and direct attribute in mixed order" do
-      Application.create(:application_type => topo_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
       Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
       Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
 
@@ -232,6 +232,34 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
                                        {:name => "source_s2"},
                                        {:name => "source_s1"},
                                        {:name => "source_s3"}
+                                     ])
+    end
+
+    it "succeeds based on an association count with a secondary attribute" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count&sort_by[]=name",
+                                     [
+                                       {:name => "source_s1"},
+                                       {:name => "source_s3"},
+                                       {:name => "source_s2"}
+                                     ])
+    end
+
+    it "succeeds based on an association count with a secondary attribute in reverse order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count&sort_by[]=name:desc",
+                                     [
+                                       {:name => "source_s3"},
+                                       {:name => "source_s1"},
+                                       {:name => "source_s2"}
                                      ])
     end
   end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -197,14 +197,14 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     end
 
     it "succeeds with an association attribute and direct attribute in mixed order" do
-      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s1, :tenant => tenant)
       Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
-      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
 
-      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=name:desc&sort_by[]=application_types.display_name:asc",
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.display_name:asc&sort_by[]=name:desc",
                                      [
-                                       {:name => "source_s3"},
                                        {:name => "source_s2"},
+                                       {:name => "source_s3"},
                                        {:name => "source_s1"}
                                      ])
     end
@@ -214,7 +214,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
       Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
       Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
 
-      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count&sort_by[]=application_types.display_name",
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count&sort_by[]=name",
                                      [
                                        {:name => "source_s3"},
                                        {:name => "source_s1"},

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     it "succeeds with an association attribute and direct attribute in mixed order" do
       Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
       Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
-      Application.create(:application_type => cost_apptype ,   :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
 
       expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=name:desc&sort_by[]=application_types.display_name:asc",
                                      [
@@ -212,7 +212,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     it "succeeds based on an association count" do
       Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
       Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype ,   :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
 
       expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count&sort_by[]=application_types.display_name",
                                      [
@@ -225,7 +225,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     it "succeeds based on an association count in reverse order" do
       Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
       Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
-      Application.create(:application_type => topo_apptype ,   :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
 
       expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[]=application_types.@count:desc",
                                      [


### PR DESCRIPTION
Enhancing sort_by to support sorting on single level association attribute.

  Usage: ```sort_by: association.attr[:[asc|desc]]```

where the association is the pluralized association, i.e. application_types

Also, allows sorting by the association count.

  Usage: ```sort_by: assocation.@count[:[asc|desc]]```


Fix for TPINVTRY-770