### PR TITLE
Only write the x.y version when generating openapi

### DIFF
--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -34,7 +34,7 @@ module Insights
           end
 
           def openapi_file
-            @openapi_file ||= Rails.root.join("public", "doc", "openapi-3-v#{api_version}.0.json").to_s
+            @openapi_file ||= Rails.root.join("public", "doc", "openapi-3-v#{api_version}.json").to_s
           end
 
           def openapi_contents


### PR DESCRIPTION
When generating the openapi file only write e.g. v1.0 not v1.0.0 so that
we can tag every API change without having to create new files
everytime.