### PR TITLE
Allow filtering of tag join records based on tag attributes

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/parameters.rb
+++ b/lib/insights/api/common/application_controller_mixins/parameters.rb
@@ -87,7 +87,11 @@ module Insights
 
           def filtered
             check_if_openapi_enabled
-            Insights::API::Common::Filter.new(model, safe_params_for_list[:filter], api_doc_definition).apply
+            Insights::API::Common::Filter.new(model, safe_params_for_list[:filter], api_doc_definition, extra_attributes_for_filtering).apply
+          end
+
+          def extra_attributes_for_filtering
+            {}
           end
 
           def pagination_limit

--- a/spec/dummy/app/controllers/api/v1/sources_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/sources_controller.rb
@@ -2,6 +2,10 @@ module Api
   module V1
     class SourcesController < ApplicationController
       include Api::V1::Mixins::IndexMixin
+
+      def extra_attributes_for_filtering
+        {"undocumented" => {"type" => "string"}}
+      end
     end
   end
 end

--- a/spec/dummy/db/migrate/20200120165732_add_sources_undocumented_column.rb
+++ b/spec/dummy/db/migrate/20200120165732_add_sources_undocumented_column.rb
@@ -1,0 +1,5 @@
+class AddSourcesUndocumentedColumn < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :undocumented, :string
+  end
+end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -84,6 +84,23 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     it("key:lte")                { expect_success("sources", "filter[id][lte]=#{source_8.id}", *Source.where(Source.arel_table[:id].lteq(source_8.id))) }
   end
 
+  context "allows filtering on extra (undocumented) attributes listed in the controller" do
+    let!(:source_1) { create_source(:name => "source_a", :undocumented => "abc")  }
+    let!(:source_2) { create_source(:name => "Source_A", :undocumented => "xyz")  }
+    let!(:source_3) { create_source(:name => "source_b", :undocumented => "abc")  }
+    let!(:source_4) { create_source(:name => "Source_B", :undocumented => "xyz")  }
+    let!(:source_5) { create_source(:name => "%source_d") }
+    let!(:source_6) { create_source(:name => "%Source_D") }
+    let!(:source_7) { create_source(:name => "Source_f%") }
+    let!(:source_8) { create_source(:name => "Source_F%") }
+
+    it("key:eq single")   { expect_success("sources", "filter[undocumented][eq]=#{source_1.undocumented}", source_1, source_3) }
+    it("key:eq array")    { expect_success("sources", "filter[undocumented][eq][]=#{source_1.undocumented}&filter[undocumented][eq][]=#{source_2.undocumented}", source_1, source_2, source_3, source_4) }
+
+    it("key:eq_i single") { expect_success("sources", "filter[undocumented][eq_i]=ABC", source_1, source_3) }
+    it("key:eq_i array")  { expect_success("sources", "filter[undocumented][eq_i][]=ABC&filter[undocumented][eq_i][]=XYZ", source_1, source_2, source_3, source_4) }
+  end
+
   context "sorted results via sort_by" do
     let!(:rhev)      { SourceType.create(:name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
     let!(:openstack) { SourceType.create(:name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }


### PR DESCRIPTION
- Switch to `arel_attribute(key)` to enable use of `virtual_delegates`
- Allow filtering on extra attributes

@kbrock Please review