### PR TITLE
Increase the limit for RBAC list_groups

### DIFF
--- a/lib/insights/api/common/rbac/utilities.rb
+++ b/lib/insights/api/common/rbac/utilities.rb
@@ -3,10 +3,12 @@ module Insights
     module Common
       module RBAC
         module Utilities
+          MAX_GROUPS_LIMIT = 500
           def validate_groups
+            options = { :limit => MAX_GROUPS_LIMIT }
             Service.call(RBACApiClient::GroupApi) do |api|
               uuids = SortedSet.new
-              Service.paginate(api, :list_groups, {}).each { |group| uuids << group.uuid }
+              Service.paginate(api, :list_groups, options).each { |group| uuids << group.uuid }
               missing = @group_uuids - uuids
               raise Insights::API::Common::InvalidParameter, "The following group uuids are missing #{missing.to_a.join(",")}" unless missing.empty?
             end

--- a/lib/insights/api/common/rbac/utilities.rb
+++ b/lib/insights/api/common/rbac/utilities.rb
@@ -5,7 +5,7 @@ module Insights
         module Utilities
           MAX_GROUPS_LIMIT = 500
           def validate_groups
-            options = { :limit => MAX_GROUPS_LIMIT }
+            options = {:limit => MAX_GROUPS_LIMIT}
             Service.call(RBACApiClient::GroupApi) do |api|
               uuids = SortedSet.new
               Service.paginate(api, :list_groups, options).each { |group| uuids << group.uuid }

--- a/spec/lib/insights/api/common/rbac/share_resource_spec.rb
+++ b/spec/lib/insights/api/common/rbac/share_resource_spec.rb
@@ -10,6 +10,7 @@ describe Insights::API::Common::RBAC::ShareResource do
   end
   let(:subject) { described_class.new(options) }
   let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "account" } }
+  let(:group_pagination_options) { {:limit => Insights::API::Common::RBAC::Utilities::MAX_GROUPS_LIMIT} }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
@@ -21,7 +22,7 @@ describe Insights::API::Common::RBAC::ShareResource do
     let(:group_uuids) { ["1"] }
     let(:resource_ids) { ["1"] }
     it "raises exception if group id is invalid" do
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, group_pagination_options).and_return(groups)
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return(roles)
       expect { subject.process }.to raise_exception(Insights::API::Common::InvalidParameter)
     end
@@ -30,7 +31,7 @@ describe Insights::API::Common::RBAC::ShareResource do
   context "valid groups" do
     let(:resource_ids) { %w[4 5] }
     it "new roles" do
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, group_pagination_options).and_return(groups)
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return(roles)
       allow(api_instance).to receive(:create_roles).and_return(role1)
 
@@ -44,7 +45,7 @@ describe Insights::API::Common::RBAC::ShareResource do
     let(:resource_ids) { [resource_id1, "2"] }
     let(:permissions) { ["#{app_name}:#{resource}:order", "#{app_name}:#{resource}:read"] }
     it "update roles" do
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, group_pagination_options).and_return(groups)
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return(roles)
       allow(api_instance).to receive(:create_roles).and_return(role2)
       allow(api_instance).to receive(:get_role).with(role1.uuid).and_return(role1_detail)

--- a/spec/lib/insights/api/common/rbac/unshare_resource_spec.rb
+++ b/spec/lib/insights/api/common/rbac/unshare_resource_spec.rb
@@ -9,6 +9,7 @@ describe Insights::API::Common::RBAC::UnshareResource do
   end
   let(:subject) { described_class.new(options) }
   let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "account" } }
+  let(:group_pagination_options) { {:limit => Insights::API::Common::RBAC::Utilities::MAX_GROUPS_LIMIT} }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)
@@ -18,7 +19,7 @@ describe Insights::API::Common::RBAC::UnshareResource do
 
   shared_examples_for "#unshare" do
     it "remove resource definitions" do
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, group_pagination_options).and_return(groups)
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_roles, pagination_options).and_return([role1, role2])
       allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_policies, {}).and_return(policies)
       allow(api_instance).to receive(:get_role).with(role1.uuid).and_return(role1_detail)
@@ -33,7 +34,7 @@ describe Insights::API::Common::RBAC::UnshareResource do
   context "invalid group uuid" do
     let(:group_uuids) { %w[1] }
     it "raises exception if group id is invalid" do
-      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, {}).and_return(groups)
+      allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :list_groups, group_pagination_options).and_return(groups)
       expect { subject.process }.to raise_exception(Insights::API::Common::InvalidParameter)
     end
   end


### PR DESCRIPTION
The default value of 10 causes too many RBAC API calls, increasing
the limit to 500