### PR TITLE
Set the limit to be the max specified in the openapi.json

### DIFF
--- a/lib/insights/api/common/rbac/service.rb
+++ b/lib/insights/api/common/rbac/service.rb
@@ -15,7 +15,7 @@ module Insights
 
           def self.paginate(obj, method, pagination_options, *method_args)
             Enumerator.new do |enum|
-              opts = { :limit => 10, :offset => 0 }.merge(pagination_options)
+              opts = { :limit => 1000, :offset => 0 }.merge(pagination_options)
               count = nil
               fetched = 0
               begin

--- a/spec/lib/insights/api/common/rbac/roles_spec.rb
+++ b/spec/lib/insights/api/common/rbac/roles_spec.rb
@@ -10,7 +10,7 @@ describe Insights::API::Common::RBAC::Roles do
 
   before do
     stub_const("ENV", "RBAC_URL" => "http://localhost")
-    stub_request(:get, "http://localhost/api/rbac/v1/roles/?limit=10&name=Catalog%20Administrator&offset=0&scope=principal")
+    stub_request(:get, "http://localhost/api/rbac/v1/roles/?limit=1000&name=Catalog%20Administrator&offset=0&scope=principal")
       .to_return(:status  => 200,
                  :body    => catalog_admin.to_json,
                  :headers => response_headers)


### PR DESCRIPTION
https://github.com/RedHatInsights/insights-rbac/blob/e8816dc36041945a62b674203b9062abfcf9ae6d/docs/source/specs/openapi.json#L1491

The default of 10 causes to many back and forth between the RBAC service and the clients.