### PR TITLE
Add a concern for the #tag and #untag methods to share common code

### DIFF
--- a/app/controllers/concerns/insights/api/common/tagging_methods.rb
+++ b/app/controllers/concerns/insights/api/common/tagging_methods.rb
@@ -1,0 +1,38 @@
+module Insights
+  module API
+    module Common
+      module TaggingMethods
+        def tag
+          primary_instance = primary_collection_model.find(request_path_parts["primary_collection_id"])
+
+          applied_tags = parsed_body.collect do |i|
+            begin
+              tag = Tag.find_or_create_by!(Tag.parse(i["tag"]))
+              primary_instance.tags << tag
+              i
+            rescue ActiveRecord::RecordNotUnique
+            end
+          end.compact
+
+          # HTTP Not Modified
+          return head(304, :location => "#{instance_link(primary_instance)}/tags") if applied_tags.empty?
+
+          # HTTP Created
+          render :json => parsed_body, :status => 201, :location => "#{instance_link(primary_instance)}/tags"
+        end
+
+        def untag
+          primary_instance = primary_collection_model.find(request_path_parts["primary_collection_id"])
+
+          parsed_body.each do |i|
+            tag = Tag.find_by(Tag.parse(i["tag"]))
+            primary_instance.tags.destroy(tag) if tag
+          end
+
+          # HTTP No Content
+          head 204, :location => "#{instance_link(primary_instance)}/tags"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted from [topo-api](https://github.com/RedHatInsights/topological_inventory-api/blob/a99a329ae61f0b137cf1567b69970976946be0a0/app/controllers/api/v2x0/taggings_controller.rb#L15-L41) and [catalog-api](https://github.com/RedHatInsights/catalog-api/blob/96f11fd14d8ea652688d2b5fbbe71aecace67827/app/controllers/api/v1/tags_controller.rb#L22-L48) including https://github.com/RedHatInsights/catalog-api/pull/572