### PR TITLE
Update the Status Api for flags on `DATABASE_URL`

### DIFF
--- a/lib/insights/api/common/status.rb
+++ b/lib/insights/api/common/status.rb
@@ -4,7 +4,7 @@ module Insights
       module Status
         module Api
           def health
-            if PG::Connection.ping(ENV['DATABASE_URL']) == PG::Connection::PQPING_OK
+            if PG::Connection.ping(ENV['DATABASE_URL'].split("?").first) == PG::Connection::PQPING_OK
               head :ok
             else
               head :internal_server_error

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StatusController, :type => :request do
 
   before do
     stub_const("ENV", "BYPASS_TENANCY" => true)
-    stub_const("ENV", "DATABASE_URL" => "postgres://admin:smartvm@localhost/insights_api_common_development")
+    stub_const("ENV", "DATABASE_URL" => "postgres://admin:smartvm@localhost/insights_api_common_development?pool=5")
   end
 
   context "when the application is healthy" do
@@ -16,7 +16,9 @@ RSpec.describe StatusController, :type => :request do
 
   context "when the application is not healthy" do
     before do
-      allow(PG::Connection).to receive(:ping).with(ENV['DATABASE_URL']).and_return PG::Connection::PQPING_NO_RESPONSE
+      allow(PG::Connection).to receive(:ping)
+        .with(ENV['DATABASE_URL'].split("?").first)
+        .and_return PG::Connection::PQPING_NO_RESPONSE
     end
 
     it "returns a 500" do


### PR DESCRIPTION
before, the Status API would just ping `ENV['DATABASE_URL']` and check
for ok, this does not work for connection strings that have flags on the
end such as catalog:
`postgresql://xxx:xxx@catalog-postgresql:5432/catalog_production?encoding=utf8&pool=5&wait_timeout=5`

This updates the code to handle such a connection string.