### PR TITLE
Rename base_path to server_base_path

### DIFF
--- a/lib/insights/api/common/open_api/docs/doc_v3.rb
+++ b/lib/insights/api/common/open_api/docs/doc_v3.rb
@@ -66,8 +66,8 @@ module Insights
               end
             end
 
-            def base_path
-              @base_path ||= @content.fetch_path("servers", 0, "variables", "basePath", "default")
+            def server_base_path
+              @server_base_path ||= @content.fetch_path("servers", 0, "variables", "basePath", "default")
             end
 
             def paths
@@ -82,7 +82,7 @@ module Insights
               @routes ||= begin
                 paths.flat_map do |path, hash|
                   hash.collect do |verb, _details|
-                    p = File.join(base_path, path).gsub(/{\w*}/, ":id")
+                    p = File.join(server_base_path, path).gsub(/{\w*}/, ":id")
                     {:path => p, :verb => verb.upcase}
                   end
                 end

--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -44,18 +44,18 @@ module Insights
           end
 
           def initialize
-            app_prefix, app_name = base_path.match(/\A(.*)\/(.*)\/v\d+.\d+\z/).captures
+            app_prefix, app_name = server_base_path.match(/\A(.*)\/(.*)\/v\d+.\d+\z/).captures
             ENV['APP_NAME'] = app_name
             ENV['PATH_PREFIX'] = app_prefix
             Rails.application.reload_routes!
           end
 
-          def base_path
+          def server_base_path
             openapi_contents["servers"].first["variables"]["basePath"]["default"]
           end
 
           def applicable_rails_routes
-            rails_routes.select { |i| i.path.start_with?(base_path) }
+            rails_routes.select { |i| i.path.start_with?(server_base_path) }
           end
 
           def schemas
@@ -520,7 +520,7 @@ module Insights
           def build_paths
             applicable_rails_routes.each_with_object({}) do |route, expected_paths|
               without_format     = route.path.split("(.:format)").first
-              sub_path           = without_format.split(base_path).last.sub(/:[_a-z]*id/, "{id}")
+              sub_path           = without_format.split(server_base_path).last.sub(/:[_a-z]*id/, "{id}")
               route_destination  = route.controller.split("/").last.camelize
               controller         = "Api::V#{api_version.sub(".", "x")}::#{route_destination}Controller".safe_constantize
               klass_name         = controller.try(:presentation_name) || route_destination.singularize


### PR DESCRIPTION
This method name tripped me up for a bit as
I was thinking it was reading the base path off of disk.
I renamed it to help show that it pulls the value directly from the `servers` key
of the open api doc.