### PR TITLE
Change BYPASS_RBAC to only check for the value "true"

### DIFF
--- a/lib/insights/api/common/rbac/access.rb
+++ b/lib/insights/api/common/rbac/access.rb
@@ -34,7 +34,7 @@ module Insights
           end
 
           def self.enabled?
-            ENV['BYPASS_RBAC'].blank?
+            ENV['BYPASS_RBAC'] != "true"
           end
 
           private

--- a/spec/lib/insights/api/common/rbac/access_spec.rb
+++ b/spec/lib/insights/api/common/rbac/access_spec.rb
@@ -33,8 +33,8 @@ describe Insights::API::Common::RBAC::Access do
     expect(described_class.enabled?).to be_truthy
   end
 
-  it "rbac is enabled by default" do
-    stub_const("ENV", "BYPASS_RBAC" => "1")
+  it "rbac is disabled with ENV var BYPASS_RBAC=true" do
+    stub_const("ENV", "BYPASS_RBAC" => "true")
     expect(described_class.enabled?).to be_falsey
   end
 end


### PR DESCRIPTION
Change BYPASS_RBAC to only check for the value "true".

Based on changes in https://github.com/RedHatInsights/e2e-deploy/pull/1062 the `BYPASS_RBAC` setting was changed from not being set to defaulting to `false`.

The original logic was setup to bypass RBAC if the environment variable exists, regardless of the value.