### PR TITLE
Allow machine credentials access to the API

### DIFF
--- a/lib/insights/api/common/request.rb
+++ b/lib/insights/api/common/request.rb
@@ -72,8 +72,20 @@ module Insights
           raise IdentityError, "x-rh-identity not found"
         end
 
+        def tenant
+          @tenant ||= Insights::API::Common::Tenant.new(identity).tenant
+        end
+
         def user
           @user ||= User.new(identity)
+        end
+
+        def system
+          @system ||= System.new(identity) if identity.dig("identity", "system").present?
+        end
+
+        def auth_type
+          identity.dig("identity", "auth_type")
         end
 
         def entitlement

--- a/lib/insights/api/common/system.rb
+++ b/lib/insights/api/common/system.rb
@@ -1,0 +1,19 @@
+module Insights
+  module API
+    module Common
+      class System
+        def initialize(identity)
+          @system = identity.dig("identity", "system")
+        end
+
+        def cn
+          system["cn"]
+        end
+
+        private
+
+        attr_reader :system
+      end
+    end
+  end
+end

--- a/lib/insights/api/common/tenant.rb
+++ b/lib/insights/api/common/tenant.rb
@@ -1,0 +1,21 @@
+module Insights
+  module API
+    module Common
+      class Tenant
+        def initialize(identity)
+          @identity = identity["identity"]
+        end
+
+        def tenant
+          result = identity&.dig("account_number")
+          raise IdentityError, "Tenant key doesn't exist" if result.nil?
+          result
+        end
+
+        private
+
+        attr_reader :identity
+      end
+    end
+  end
+end

--- a/lib/insights/api/common/user.rb
+++ b/lib/insights/api/common/user.rb
@@ -24,6 +24,7 @@ module Insights
         end
 
         def tenant
+          ActiveSupport::Deprecation.warn("Please switch to request.tenant, request.user.tenant will be removed in a future release.")
           find_tenant_key
         end
 

--- a/spec/lib/insights/api/common/request_spec.rb
+++ b/spec/lib/insights/api/common/request_spec.rb
@@ -51,6 +51,18 @@ describe Insights::API::Common::Request do
       expect(@instance.user).to be_a(Insights::API::Common::User)
     end
 
+    it "#tenant" do
+      expect(@instance.tenant).to eq(default_account_number)
+    end
+
+    it "#system" do
+      expect(@instance.system).to be_nil
+    end
+
+    it "#auth_type" do
+      expect(@instance.auth_type).to eq("basic-auth")
+    end
+
     it "#to_h" do
       expect(@instance.to_h).to eq(:headers => forwardable_good, :original_url => "https://example.com")
     end
@@ -90,6 +102,64 @@ describe Insights::API::Common::Request do
 
     it "#request_id" do
       expect(@instance.request_id).to be_nil
+    end
+  end
+
+
+  context "with a good system request" do
+    let(:system_request) do
+      {
+        :headers      => {
+          'x-rh-identity'            => encoded_system_hash,
+          'x-rh-insights-request-id' => "01234567-89ab-cdef-0123-456789abcde",
+        },
+        :original_url => 'https://example.com'
+      }
+    end
+
+    around do |example|
+      described_class.with_request(system_request) do |instance|
+        @instance = instance
+        example.call
+      end
+    end
+
+    it "#original_url" do
+      expect(@instance.original_url).to eq "https://example.com"
+    end
+
+    describe "#headers" do
+      it "return a headers object" do
+        expect(@instance.headers).to be_a(ActionDispatch::Http::Headers)
+      end
+
+      it "allows case-insensitive lookup" do
+        expect(@instance.headers["X-Rh-Identity"]).to eq encoded_system_hash
+      end
+    end
+
+    it "#user" do
+      expect(@instance.user).to be_a(Insights::API::Common::User)
+    end
+
+    it "#tenant" do
+      expect(@instance.tenant).to eq(default_account_number)
+    end
+
+    it "#system" do
+      expect(@instance.system).to be_a(Insights::API::Common::System)
+    end
+
+    it "#auth_type" do
+      expect(@instance.auth_type).to eq("cert-auth")
+    end
+
+    it "#request_id" do
+      expect(@instance.request_id).to eq "01234567-89ab-cdef-0123-456789abcde"
+    end
+
+    it "#identity" do
+      expect(@instance.identity).to eq default_system_hash
     end
   end
 

--- a/spec/lib/insights/api/common/system_spec.rb
+++ b/spec/lib/insights/api/common/system_spec.rb
@@ -1,0 +1,28 @@
+describe Insights::API::Common::User do
+  let(:encoded) { encoded_system_hash }
+  let(:request_bad) { { :headers => {:blah => 'blah' }, :original_url => 'whatever' } }
+  let(:request_good) do
+    { :headers => { 'x-rh-identity' => encoded }, :original_url => 'whatever' }
+  end
+
+  around do |example|
+    Insights::API::Common::Request.with_request(request_good) { example.call }
+  end
+
+  it "raises an exception if Request.current is not set" do
+    Insights::API::Common::Request.current = nil
+    expect { Insights::API::Common::Request.current.system.cn }.to raise_exception(NoMethodError)
+  end
+
+  context "system getter methods" do
+    let(:system)      { Insights::API::Common::Request.current.system }
+
+    it "#cn" do
+      expect(system.cn).to eq(default_system_cn)
+    end
+
+    it "raises an exception for keys that do not exist" do
+      expect { system.username }.to raise_exception(NoMethodError)
+    end
+  end
+end

--- a/spec/lib/insights/api/common/tenant_spec.rb
+++ b/spec/lib/insights/api/common/tenant_spec.rb
@@ -1,0 +1,24 @@
+describe Insights::API::Common::Tenant do
+  let(:encoded)     { encoded_user_hash }
+  let(:request_bad) { { :headers => {:blah => 'blah' }, :original_url => 'whatever' } }
+  let(:request_good) do
+    { :headers => { 'x-rh-identity' => encoded }, :original_url => 'whatever' }
+  end
+
+  around do |example|
+    Insights::API::Common::Request.with_request(request_good) { example.call }
+  end
+
+  it "raises an exception if Request.current is not set" do
+    Insights::API::Common::Request.current = nil
+    expect { Insights::API::Common::Request.current.tenant }.to raise_exception(NoMethodError)
+  end
+
+  context "tenant getter methods" do
+    let(:tenant)        { Insights::API::Common::Request.current.tenant }
+
+    it "#tenant" do
+      expect(tenant).to eq(default_account_number)
+    end
+  end
+end

--- a/spec/support/user_header_spec_helper.rb
+++ b/spec/support/user_header_spec_helper.rb
@@ -41,6 +41,41 @@ module UserHeaderSpecHelper
     }
   }.freeze
 
+  DEFAULT_SYSTEM = {
+    "entitlements" => {
+      "ansible"          => {
+        "is_entitled" => true
+      },
+      "hybrid_cloud"     => {
+        "is_entitled" => true
+      },
+      "insights"         => {
+        "is_entitled" => true
+      },
+      "migrations"       => {
+        "is_entitled" => true
+      },
+      "openshift"        => {
+        "is_entitled" => true
+      },
+      "smart_management" => {
+        "is_entitled" => true
+      }
+    },
+    "identity" => {
+      "account_number" => "0369233",
+      "type"           => "System",
+      "auth_type"      => "cert-auth",
+      "system"         => {
+        "cn" => "certificate"
+      },
+      "internal"       => {
+        "org_id"    => "3340851",
+        "auth_time" => 6300
+      }
+    }
+  }.freeze
+
   def default_account_number
     default_user_hash["identity"]["account_number"]
   end
@@ -51,6 +86,10 @@ module UserHeaderSpecHelper
 
   def default_auth_type
     default_user_hash["identity"]["auth_type"]
+  end
+
+  def default_system_cn
+    default_system_hash["identity"]["system"]["cn"]
   end
 
   def encode(val)
@@ -66,7 +105,15 @@ module UserHeaderSpecHelper
     encode(hash || DEFAULT_USER)
   end
 
+  def encoded_system_hash(hash = nil)
+    encode(hash || DEFAULT_SYSTEM)
+  end
+
   def default_user_hash
     Marshal.load(Marshal.dump(DEFAULT_USER))
+  end
+
+  def default_system_hash
+    Marshal.load(Marshal.dump(DEFAULT_SYSTEM))
   end
 end


### PR DESCRIPTION
When a machine credential connects to 3scale there is no user key in the headers but rather a system key.

Depends on: https://github.com/RedHatInsights/insights-api-common-rails/pull/162
Relates to JIRA: https://projects.engineering.redhat.com/browse/TPINVTRY-870