### PR TITLE
Separate RBAC network error out from common errors

### DIFF
--- a/spec/lib/insights/api/common/rbac/service_spec.rb
+++ b/spec/lib/insights/api/common/rbac/service_spec.rb
@@ -1,5 +1,6 @@
 describe Insights::API::Common::RBAC::Service do
-  let(:rbac_ex) { RBACApiClient::ApiError.new("kaboom") }
+  let(:rbac_none_zero_ex) { RBACApiClient::ApiError.new(:messsage => "kaboom", :code => 1) }
+  let(:rbac_zero_ex) { RBACApiClient::ApiError.new(:messsage => "kaboom", :code => 0) }
   let(:page_size) { 3 }
   let(:page1_data) { [1, 2, 3] }
   let(:page2_data) { [4, 5, 6] }
@@ -16,9 +17,16 @@ describe Insights::API::Common::RBAC::Service do
     expect do
       stub_const("ENV", "RBAC_URL" => 'http://www.example.com')
       described_class.call(RBACApiClient::StatusApi) do |_klass|
-        raise rbac_ex
+        raise rbac_none_zero_ex
       end
     end.to raise_exception(RBACApiClient::ApiError)
+
+    expect do
+      stub_const("ENV", "RBAC_URL" => 'http://www.example.com')
+      described_class.call(RBACApiClient::StatusApi) do |_klass|
+        raise rbac_zero_ex
+      end
+    end.to raise_exception(Insights::API::Common::RBAC::NetworkError)
   end
 
   context "pagination" do

--- a/spec/lib/insights/api/common/rbac/service_spec.rb
+++ b/spec/lib/insights/api/common/rbac/service_spec.rb
@@ -1,6 +1,7 @@
 describe Insights::API::Common::RBAC::Service do
   let(:rbac_none_zero_ex) { RBACApiClient::ApiError.new(:messsage => "kaboom", :code => 1) }
   let(:rbac_zero_ex) { RBACApiClient::ApiError.new(:messsage => "kaboom", :code => 0) }
+  let(:rbac_nil_ex) { RBACApiClient::ApiError.new(:messsage => "kaboom") }
   let(:page_size) { 3 }
   let(:page1_data) { [1, 2, 3] }
   let(:page2_data) { [4, 5, 6] }
@@ -27,6 +28,13 @@ describe Insights::API::Common::RBAC::Service do
         raise rbac_zero_ex
       end
     end.to raise_exception(Insights::API::Common::RBAC::NetworkError)
+
+    expect do
+      stub_const("ENV", "RBAC_URL" => 'http://www.example.com')
+      described_class.call(RBACApiClient::StatusApi) do |_klass|
+        raise rbac_nil_ex
+      end
+    end.to raise_exception(Insights::API::Common::RBAC::TimedOutError)
   end
 
   context "pagination" do


### PR DESCRIPTION
The Auto Generated clients use libcurl to perform network operations.
lib curl can detect
1. Connection failures (bad host, not reachable)
2. Timeout errors
3. Actual HTTP status codes coming from the API Server

https://github.com/RedHatInsights/insights-rbac-api-client-ruby/blob/41cddab91c06ef34abec537a8c83e08ca4a8d2be/lib/rbac-api-client/api_client.rb#L56
 
This PR adds the ability to make distinctions between Network Error, Time out error and actual API errors which allows the services to respond with appropriate HTTP error codes when communication between services fails (e.g. Catalog talking to RBAC service and the RBAC service is down)