### PR TITLE
Sort by association attribute and count

### DIFF
--- a/lib/insights/api/common/paginated_response_v2.rb
+++ b/lib/insights/api/common/paginated_response_v2.rb
@@ -23,13 +23,13 @@ module Insights
           end
         end
 
-        # Condenses parameter values for handling multi-level associations and returns an array
-        # of key, value pairs.
+        # Condenses parameter values for handling multi-level associations
+        # and returns an array of key, value pairs.
         #
-        # Input: { "association" => { "attribute" => "value" }, "direct_attribute" = "value2" }
+        # Input:  { "association" => { "attribute" => "value" }, "direct_attribute" = "value2" }
         # Output: { "association.attribute" => "value", "direct_attribute" => "value2" }
         #
-        # Input: { "association" => { "attribute" => "value" }, "association2" => "attribute2" = "value2" }
+        # Input:  { "association" => { "attribute" => "value" }, "association2" => "attribute2" = "value2" }
         # Output: { "association.attribute" => "value", "association2.attribute2" => "value2" }
         #
         def compact_parameter(param)
@@ -38,9 +38,9 @@ module Insights
 
           param.each do |k, v|
             result << if v.kind_of?(Hash) || v.kind_of?(ActionController::Parameters)
-                        secondary_key = v.keys.first
+                        secondary_key   = v.keys.first
                         secondary_value = v[secondary_key]
-                        [ "#{k}.#{secondary_key}", secondary_value]
+                        ["#{k}.#{secondary_key}", secondary_value]
                       else
                         [k, v]
                       end

--- a/lib/insights/api/common/paginated_response_v2.rb
+++ b/lib/insights/api/common/paginated_response_v2.rb
@@ -2,35 +2,122 @@ module Insights
   module API
     module Common
       class PaginatedResponseV2 < PaginatedResponse
+
+        # GraphQL name regex: /[_A-Za-z][_0-9A-Za-z]*/
+        ASSOCIATION_COUNT_ATTR = "__count".freeze
+
         attr_reader :limit, :offset, :sort_by
+
+        def records
+          @records ||= begin
+            res = @base_query.order(:id).limit(limit).offset(offset)
+
+            select_for_associations, group_by_associations = sort_by_associations_query_parameters
+            res = res.select(*select_for_associations)          if select_for_associations.present?
+            res = res.left_outer_joins(*sort_by_associations)   if sort_by_associations.present?
+            res = res.group(group_by_associations)              if group_by_associations.present?
+
+            order_options = sort_by_options(res.klass)
+            res = res.reorder(order_options) if order_options.present?
+            res
+          end
+        end
+
+        # Condenses parameter values for handling multi-level associations and returns an array
+        # of key, value pairs.
+        #
+        # Input: { "association" => { "attribute" => "value" }, "direct_attribute" = "value2" }
+        # Output: { "association.attribute" => "value", "direct_attribute" => "value2" }
+        #
+        # Input: { "association" => { "attribute" => "value" }, "association2" => "attribute2" = "value2" }
+        # Output: { "association.attribute" => "value", "association2.attribute2" => "value2" }
+        #
+        def compact_parameter(param)
+          result = []
+          return result if param.blank?
+
+          param.each do |k, v|
+            result << if v.kind_of?(Hash) || v.kind_of?(ActionController::Parameters)
+                        secondary_key = v.keys.first
+                        secondary_value = v[secondary_key]
+                        [ "#{k}.#{secondary_key}", secondary_value]
+                      else
+                        [k, v]
+                      end
+          end
+          result
+        end
 
         private
 
         def sort_by_options(model)
           @sort_by_options ||= begin
-            sort_options = []
-            return sort_options if sort_by.blank?
-
-            sort_by.each do |sort_attr, sort_order|
+            compact_parameter(sort_by).collect do |sort_attr, sort_order|
               sort_order = "asc" if sort_order.blank?
-              arel = model.arel_attribute(sort_attr)
-              arel = (sort_order == "desc") ? arel.desc : arel.asc
-              sort_options << arel
+              arel = if sort_attr.include?('.')
+                       association, sort_attr = sort_attr.split('.')
+                       association_class = association.classify.constantize
+                       if sort_attr == ASSOCIATION_COUNT_ATTR
+                         Arel.sql("COUNT (#{association_class.table_name}.id)")
+                       else
+                         association_class.arel_attribute(sort_attr)
+                       end
+                     else
+                       model.arel_attribute(sort_attr)
+                     end
+              (sort_order == "desc") ? arel.desc : arel.asc
             end
-            sort_options
           end
+        end
+
+        def sort_by_associations
+          @sort_by_associations ||= begin
+            compact_parameter(sort_by).collect do |sort_attr, sort_order|
+              next unless sort_attr.include?('.')
+
+              sort_attr.split('.').first.to_sym
+            end.compact.uniq
+          end
+        end
+
+        def sort_by_associations_query_parameters
+          select_for_associations = []
+          group_by_associations   = []
+          count_selects           = []
+
+          compact_parameter(sort_by).each do |sort_attr, _sort_order|
+            next unless sort_attr.include?('.')
+
+            association, attr = sort_attr.split('.')
+
+            base_id  = "#{@base_query.table_name}.id"
+            base_all = "#{@base_query.table_name}.*"
+            select_for_associations << base_id << base_all if select_for_associations.empty?
+            group_by_associations   << base_id << base_all if group_by_associations.empty?
+
+            if attr == ASSOCIATION_COUNT_ATTR
+              count_selects << Arel.sql("COUNT (#{association.classify.constantize.table_name}.id)")
+            else
+              arel_attr = association.classify.constantize.arel_attribute(attr)
+              select_for_associations << arel_attr
+              group_by_associations << arel_attr
+            end
+          end
+          select_for_associations.append(*count_selects) unless count_selects.empty?
+
+          [select_for_associations.compact.uniq, group_by_associations.compact.uniq]
         end
 
         def validate_sort_by
           return unless sort_by.present?
           raise ArgumentError, "Invalid sort_by parameter specified \"#{sort_by}\"" unless sort_by.kind_of?(ActionController::Parameters) || sort_by.kind_of?(Hash)
 
-          sort_by.each { |sort_attr, sort_order| validate_sort_by_directive(sort_attr, sort_order) }
+          compact_parameter(sort_by).each { |sort_attr, sort_order| validate_sort_by_directive(sort_attr, sort_order) }
         end
 
         def validate_sort_by_directive(sort_attr, sort_order)
           order = sort_order.blank? ? "asc" : sort_order
-          raise ArgumentError, "Invalid sort_by directive specified \"#{sort_attr}=#{sort_order}\"" unless sort_attr.match?(/^[a-z\\-_]+$/) && order.match?(/^(asc|desc)$/)
+          raise ArgumentError, "Invalid sort_by directive specified \"#{sort_attr}=#{sort_order}\"" unless sort_attr.match?(/^[a-z\-_\.]+$/) && order.match?(/^(asc|desc)$/)
         end
       end
     end

--- a/spec/dummy/app/controllers/api/v2/application_types_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/application_types_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V2
+    class ApplicationTypesController < ApplicationController
+      include Api::V2::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v2/applications_controller.rb
+++ b/spec/dummy/app/controllers/api/v2/applications_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V2
+    class ApplicationsController < ApplicationController
+      include Api::V2::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v2x0.rb
+++ b/spec/dummy/app/controllers/api/v2x0.rb
@@ -6,13 +6,15 @@ module Api
       end
     end
 
-    class AuthenticationsController < Api::V1x0::AuthenticationsController; end
-    class VmsController             < Api::V1x0::VmsController; end
-    class PersonsController         < Api::V1x0::PersonsController; end
-    class ExtrasController          < Api::V1x0::ExtrasController; end
-    class ErrorsController          < Api::V1x0::ErrorsController; end
-    class GraphqlController         < Api::V2::GraphqlController; end
-    class SourcesController         < Api::V2::SourcesController; end
-    class SourceTypesController     < Api::V2::SourceTypesController; end
+    class ApplicationsController     < Api::V2::ApplicationsController; end
+    class ApplicationTypesController < Api::V2::ApplicationTypesController; end
+    class AuthenticationsController  < Api::V1x0::AuthenticationsController; end
+    class VmsController              < Api::V1x0::VmsController; end
+    class PersonsController          < Api::V1x0::PersonsController; end
+    class ExtrasController           < Api::V1x0::ExtrasController; end
+    class ErrorsController           < Api::V1x0::ErrorsController; end
+    class GraphqlController          < Api::V2::GraphqlController; end
+    class SourcesController          < Api::V2::SourcesController; end
+    class SourceTypesController      < Api::V2::SourceTypesController; end
   end
 end

--- a/spec/dummy/app/models/application.rb
+++ b/spec/dummy/app/models/application.rb
@@ -1,0 +1,7 @@
+class Application < ApplicationRecord
+  include TenancyConcern
+  belongs_to :source
+  belongs_to :application_type
+
+  validates :availability_status, :inclusion => {:in => %w[available unavailable]}, :allow_nil => true
+end

--- a/spec/dummy/app/models/application_type.rb
+++ b/spec/dummy/app/models/application_type.rb
@@ -1,0 +1,4 @@
+class ApplicationType < ApplicationRecord
+  has_many :applications
+  has_many :sources, :through => :applications
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       get "/error_nested", :to => "errors#error_nested"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
+      resources :applications, :only => [:index]
+      resources :application_types, :only => [:index]
       resources :authentications, :only => [:create, :update]
       resources :vms, :only => [:index, :show]
       resources :persons, :only => [:index, :create, :show, :update]

--- a/spec/dummy/db/migrate/20200121140744_add_applications_and_application_types.rb
+++ b/spec/dummy/db/migrate/20200121140744_add_applications_and_application_types.rb
@@ -1,0 +1,19 @@
+class AddApplicationsAndApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :application_types do |t|
+      t.string :name, :null => false
+      t.string :display_name
+      t.index %w[name], :unique => true
+      t.timestamps
+    end
+
+    create_table :applications do |t|
+      t.string :availability_status
+      t.string :availability_status_error
+      t.references :tenant,           :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :source,           :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :application_type, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/public/doc/openapi-3-v2.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v2.0.0.json
@@ -20,6 +20,140 @@
     }
   ],
   "paths": {
+    "/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes",
+        "operationId": "listApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types/{id}": {
+      "get": {
+        "summary": "Show an existing ApplicationType",
+        "operationId": "showApplicationType",
+        "description": "Returns a ApplicationType object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationType info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationType"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications": {
+      "get": {
+        "summary": "List Applications",
+        "operationId": "listApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "summary": "Show an existing Application",
+        "operationId": "showApplication",
+        "description": "Returns a Application object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Application info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Application"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/authentications": {
       "get": {
         "summary": "List Authentications",
@@ -407,6 +541,98 @@
         }
       }
     },
+    "/sources/{id}/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes for Source",
+        "operationId": "listSourceApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/applications": {
+      "get": {
+        "summary": "List Applications for Source",
+        "operationId": "listSourceApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sources/{id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",
@@ -696,6 +922,109 @@
       }
     },
     "schemas": {
+      "Application": {
+        "type": "object",
+        "properties": {
+          "application_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "tenant": {
+            "type": "string",
+            "readOnly": true
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            }
+          }
+        }
+      },
+      "ApplicationType": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "dependent_applications": {
+            "type": "object"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "supported_authentication_types": {
+            "type": "object"
+          },
+          "supported_source_types": {
+            "type": "object"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationTypesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationType"
+            }
+          }
+        }
+      },
       "Authentication": {
         "additionalProperties": false,
         "type": "object",

--- a/spec/lib/insights/api/common/paginated_response_v2_spec.rb
+++ b/spec/lib/insights/api/common/paginated_response_v2_spec.rb
@@ -1,0 +1,43 @@
+describe Insights::API::Common::PaginatedResponseV2 do
+  context "compact_parameter method" do
+    let(:base_query) { double("AR:Clause", :count => 100) }
+    let(:request)    { double("Request", :original_url => "http://example.com/api/v2.0/graphql") }
+    let(:this)       { described_class.new(:base_query => base_query, :request => request) }
+
+    it "supports compound attribute specifications" do
+      parameters  = {"association" => {"attribute" => "value"}, "direct_attribute" => "value2"}
+      expectation = [["association.attribute", "value"], ["direct_attribute", "value2"]]
+
+      expect(this.public_send(:compact_parameter, parameters)).to(eq(expectation))
+    end
+
+    it "supports multiple association specifications" do
+      parameters  = {"association" => {"attribute" => "value"}, "association2" => {"attribute2" => "value2"}}
+      expectation = [["association.attribute", "value"], ["association2.attribute2", "value2"]]
+
+      expect(this.public_send(:compact_parameter, parameters)).to(eq(expectation))
+    end
+
+    it "supports association specification with multiple attributes" do
+      parameters  = {"association" => {"attribute1" => "value1", "attribute2" => "value2"}}
+      expectation = [["association.attribute1", "value1"], ["association.attribute2", "value2"]]
+
+      expect(this.public_send(:compact_parameter, parameters)).to(eq(expectation))
+    end
+
+    it "supports compound multiple association specifications" do
+      parameters = {
+        "association"      => {"attribute1" => "value1", "attribute2" => "value2"},
+        "direct_attribute" => "value3",
+        "association2"     => {"attribute4" => "value4", "attribute5" => "value5"}
+      }
+      expectation = [
+        ["association.attribute1", "value1"], ["association.attribute2", "value2"],
+        ["direct_attribute", "value3"],
+        ["association2.attribute4", "value4"], ["association2.attribute5", "value5"]
+      ]
+
+      expect(this.public_send(:compact_parameter, parameters)).to(eq(expectation))
+    end
+  end
+end

--- a/spec/requests/api/v2.0/graphql_spec.rb
+++ b/spec/requests/api/v2.0/graphql_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
   let!(:source_typeV) { SourceType.create(:name => "vmware_sample", :product_name => "VmWare vCenter", :vendor => "vmware") }
   let!(:source_typeO) { SourceType.create(:name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
 
+  let!(:catalog_apptype) { ApplicationType.create(:name => "/insights/platform/catalog", :display_name => "Catalog") }
+  let!(:cost_apptype)    { ApplicationType.create(:name => "/insights/platform/cost-management", :display_name => "Cost Management") }
+  let!(:topo_apptype)    { ApplicationType.create(:name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory") }
+
   context "supports result sorting" do
     before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
 
@@ -53,6 +57,479 @@ RSpec.describe Insights::API::Common::GraphQL, :type => :request do
       expect(response.status).to eq(200)
       expect(response.parsed_body["data"]["source_types"].collect { |st| [st["vendor"], st["product_name"]] })
         .to eq([["redhat", "RedHat Virtualization"], ["redhat", "OpenStack"], ["vmware", "VmWare vCenter"]])
+    end
+  end
+
+  context "supports sort_by with association attributes" do
+    before do
+      stub_const("ENV", "BYPASS_TENANCY" => nil)
+
+      @source_s1 = Source.create!(:tenant => tenant, :name => "source_s1", :source_type => source_typeR)
+      @source_s2 = Source.create!(:tenant => tenant, :name => "source_s2", :source_type => source_typeR)
+      @source_s3 = Source.create!(:tenant => tenant, :name => "source_s3", :source_type => source_typeR)
+    end
+
+    it "sorting with an association attribute in ascending order" do
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { display_name: null } }) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Cost Management" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting with an association attribute in descending order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { display_name: "desc" } } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Cost Management" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting with an association attribute and direct attribute in mixed order" do
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s" } }, sort_by: { application_types: { display_name: "asc" }, name: "desc" } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Cost Management" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Cost Management" }
+              ]
+            }
+          ]
+        }'))
+    end
+  end
+
+  context "supports sort_by with association count" do
+    before do
+      stub_const("ENV", "BYPASS_TENANCY" => nil)
+
+      @source_s1 = Source.create!(:tenant => tenant, :name => "source_s1", :source_type => source_typeR)
+      @source_s2 = Source.create!(:tenant => tenant, :name => "source_s2", :source_type => source_typeR)
+      @source_s3 = Source.create!(:tenant => tenant, :name => "source_s3", :source_type => source_typeR)
+    end
+
+    it "sorting based on an association count" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s" } }, sort_by: { application_types: { __count: null }, name: null } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count in reverse order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { __count: "desc" } } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count with secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { __count: null }, name: null } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on a direct association count with descending secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { applications: { __count: "asc" }, name: "desc" } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count with secondary field" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { __count: null }, name: null } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s3",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+                { "display_name": "Catalog" }
+              ]
+            },
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on a direct association count in reverse order with secondary attribute in descending order" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s4, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { applications: { __count: "desc" }, name: "desc" } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Catalog" },
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+              ]
+            }
+          ]
+        }'))
+    end
+
+    it "sorting based on an association count in reverse order with secondary attribute in descending order" do
+      @source_s4 = Source.create!(:tenant => tenant, :name => "source_s4", :source_type => source_typeR)
+
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s4, :tenant => tenant)
+
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          sources(filter: { name: { starts_with: "source_s"}}, sort_by: { application_types: { __count: "desc" }, name: "desc" } ) {
+            name
+            application_types {
+              display_name
+            }
+          }
+        }'})
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to eq(JSON.parse('
+        {
+          "sources": [
+            {
+              "name": "source_s2",
+              "application_types": [
+                { "display_name": "Catalog" },
+                { "display_name": "Cost Management" },
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s4",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s3",
+              "application_types": [
+                { "display_name": "Topological Inventory" }
+              ]
+            },
+            {
+              "name": "source_s1",
+              "application_types": [
+              ]
+            }
+          ]
+        }'))
     end
   end
 end

--- a/spec/requests/api/v2.0/paginated_response_spec.rb
+++ b/spec/requests/api/v2.0/paginated_response_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe("Insights::API::Common::PaginatedResponseV2", :type => :request) 
   let(:tenant)          { Tenant.create!(:name => "default", :external_tenant => external_tenant) }
   let(:source_type)     { SourceType.create(:name => "rhev", :product_name => "RedHat Virtualization", :vendor => "redhat") }
 
+  let!(:catalog_apptype) { ApplicationType.create(:name => "/insights/platform/catalog", :display_name => "Catalog") }
+  let!(:cost_apptype)    { ApplicationType.create(:name => "/insights/platform/cost-management", :display_name => "Cost Management") }
+  let!(:topo_apptype)    { ApplicationType.create(:name => "/insights/platform/topological-inventory", :display_name => "Topological Inventory") }
+
   def create_source(attrs = {})
     Source.create!(attrs.merge(:tenant => tenant, :source_type => source_type))
   end
@@ -119,6 +123,107 @@ RSpec.describe("Insights::API::Common::PaginatedResponseV2", :type => :request) 
 
     it("returns a bad_request if one of the multiple sort_by order is invalid") do
       expect_failure("source_types", "sort_by[name]=asc&sort_by[vendor]=bogus", "ArgumentError: Invalid sort_by directive specified \"vendor=bogus\"")
+    end
+  end
+
+  context "sorted results via sort_by against associations" do
+    before do
+      @source_s1 = Source.create!(:tenant => tenant, :name => "source_s1", :source_type => source_type)
+      @source_s2 = Source.create!(:tenant => tenant, :name => "source_s2", :source_type => source_type)
+      @source_s3 = Source.create!(:tenant => tenant, :name => "source_s3", :source_type => source_type)
+    end
+
+    it "succeeds with single association attribute in ascending order" do
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][display_name]=",
+                                     [
+                                       {:name => "source_s2"},
+                                       {:name => "source_s1"},
+                                       {:name => "source_s3"}
+                                     ])
+    end
+
+    it "succeeds with single association attribute in descending order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][display_name]=desc",
+                                     [
+                                       {:name => "source_s2"},
+                                       {:name => "source_s3"},
+                                       {:name => "source_s1"}
+                                     ])
+    end
+
+    it "succeeds with an association attribute and direct attribute in mixed order" do
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][display_name]=asc&sort_by[name]=desc",
+                                     [
+                                       {:name => "source_s2"},
+                                       {:name => "source_s3"},
+                                       {:name => "source_s1"}
+                                     ])
+    end
+
+    it "succeeds based on an association count" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][__count]=&sort_by[name]=",
+                                     [
+                                       {:name => "source_s3"},
+                                       {:name => "source_s1"},
+                                       {:name => "source_s2"}
+                                     ])
+    end
+
+    it "succeeds based on an association count in reverse order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][__count]=desc",
+                                     [
+                                       {:name => "source_s2"},
+                                       {:name => "source_s1"},
+                                       {:name => "source_s3"}
+                                     ])
+    end
+
+    it "succeeds based on an association count with a secondary attribute" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][__count]=&sort_by[name]=",
+                                     [
+                                       {:name => "source_s1"},
+                                       {:name => "source_s3"},
+                                       {:name => "source_s2"}
+                                     ])
+    end
+
+    it "succeeds based on an association count with a secondary attribute in reverse order" do
+      Application.create(:application_type => catalog_apptype, :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => topo_apptype,    :source => @source_s2, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s1, :tenant => tenant)
+      Application.create(:application_type => cost_apptype,    :source => @source_s3, :tenant => tenant)
+
+      expect_success_ordered_objects("sources", "filter[name][starts_with]=source_s&sort_by[application_types][__count]&sort_by[name]=desc",
+                                     [
+                                       {:name => "source_s3"},
+                                       {:name => "source_s1"},
+                                       {:name => "source_s2"}
+                                     ])
     end
   end
 end


### PR DESCRIPTION
- Adding support for sorting by association attribute and association count using the object based specification for the sort_by parameter.

_Note_: with sort_by coming in as hash parameters, GraphQL does not like periods or @ in parameter names, periods are gone, but the **@ count** needed to be changed, went with **__count**.

Fix for: TPINVTRY-770
Depends on: https://github.com/RedHatInsights/insights-api-common-rails/pull/165