### PR TITLE
Accept user defined headers in RBAC calls

### DIFF
--- a/lib/insights/api/common/rbac/service.rb
+++ b/lib/insights/api/common/rbac/service.rb
@@ -8,9 +8,9 @@ module Insights
         class TimedOutError < StandardError; end
 
         class Service
-          def self.call(klass)
+          def self.call(klass, extra_headers = {})
             setup
-            yield init(klass)
+            yield init(klass, extra_headers)
           rescue RBACApiClient::ApiError => err
             raise TimedOutError.new('Connection timed out') if err.code.nil?
             raise NetworkError.new(err.message) if err.code.zero?
@@ -55,8 +55,8 @@ module Insights
             end
           end
 
-          private_class_method def self.init(klass)
-            headers = Insights::API::Common::Request.current_forwardable
+          private_class_method def self.init(klass, extra_headers)
+            headers = Insights::API::Common::Request.current_forwardable.merge(extra_headers)
             klass.new.tap do |api|
               api.api_client.default_headers = api.api_client.default_headers.merge(headers)
             end

--- a/spec/lib/insights/api/common/rbac/service_spec.rb
+++ b/spec/lib/insights/api/common/rbac/service_spec.rb
@@ -57,4 +57,14 @@ describe Insights::API::Common::RBAC::Service do
       end.to raise_exception(StandardError)
     end
   end
+
+  context "user headers" do
+    it 'includes user headers in default headers' do
+      stub_const("ENV", "RBAC_URL" => 'http://www.example.com')
+      allow(Insights::API::Common::Request).to receive(:current_forwardable).and_return(:x => 1)
+      described_class.call(RBACApiClient::StatusApi, 'x-rh-user-header' => 'value') do |api|
+        expect(api.api_client.default_headers).to include(:x => 1, 'x-rh-user-header' => 'value')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some RBAC calls require extra headers.