### PR TITLE
Remove the limits and offset to get data in single call

### DIFF
--- a/lib/insights/api/common/rbac/access.rb
+++ b/lib/insights/api/common/rbac/access.rb
@@ -4,7 +4,6 @@ module Insights
       module RBAC
         class Access
           attr_reader :acl
-          DEFAULT_LIMIT = 500
           ADMIN_SCOPE = "admin"
           GROUP_SCOPE = "group"
           USER_SCOPE = "user"
@@ -15,7 +14,7 @@ module Insights
 
           def process
             Service.call(RBACApiClient::AccessApi) do |api|
-              @acls ||= Service.paginate(api, :get_principal_access, {:limit => DEFAULT_LIMIT}, @app_name_filter).to_a
+              @acls ||= api.get_principal_access(@app_name_filter).data
             end
             self
           end

--- a/spec/lib/insights/api/common/rbac/access_spec.rb
+++ b/spec/lib/insights/api/common/rbac/access_spec.rb
@@ -6,7 +6,7 @@ describe Insights::API::Common::RBAC::Access do
   let(:access_obj) { rbac_access.process }
   let(:api_instance) { double }
   let(:rs_class) { class_double("Insights::API::Common::RBAC::Service").as_stubbed_const(:transfer_nested_constants => true) }
-  let(:opts) { { :limit => described_class::DEFAULT_LIMIT } }
+  let(:result) { instance_double(RBACApiClient::AccessPagination, :data => data) }
 
   before do
     stub_const("ENV", "APP_NAME" => app_name)
@@ -22,30 +22,41 @@ describe Insights::API::Common::RBAC::Access do
     expect(described_class.enabled?).to be_falsey
   end
 
-  it "checks admin scope" do
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([admin_scope])
-    expect(access_obj.accessible?(resource, 'read')).to be_truthy
-    expect(access_obj.admin_scope?(resource, 'read')).to be_truthy
-    expect(access_obj.user_scope?(resource, 'read')).to be_falsey
-    expect(access_obj.group_scope?(resource, 'read')).to be_falsey
+  context "admin scope" do
+    let(:data) { [admin_scope] }
+    it "checks admin scope" do
+      allow(api_instance).to receive(:get_principal_access).with(app_name).and_return(result)
+      expect(access_obj.accessible?(resource, 'read')).to be_truthy
+      expect(access_obj.admin_scope?(resource, 'read')).to be_truthy
+      expect(access_obj.user_scope?(resource, 'read')).to be_falsey
+      expect(access_obj.group_scope?(resource, 'read')).to be_falsey
+    end
   end
 
-  it "checks user scope" do
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([user_scope])
-
-    expect(access_obj.accessible?(resource, 'read', app_name)).to be_truthy
-    expect(access_obj.user_scope?(resource, 'read', app_name)).to be_truthy
+  context "user scope" do
+    let(:data) { [user_scope] }
+    it "checks user scope" do
+      allow(api_instance).to receive(:get_principal_access).with(app_name).and_return(result)
+      expect(access_obj.accessible?(resource, 'read', app_name)).to be_truthy
+      expect(access_obj.user_scope?(resource, 'read', app_name)).to be_truthy
+    end
   end
 
-  it "checks group scope" do
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([group_scope])
-    expect(access_obj.accessible?(resource, 'read', app_name)).to be_truthy
-    expect(access_obj.group_scope?(resource, 'read')).to be_truthy
+  context "group scope" do
+    let(:data) { [group_scope] }
+    it "checks group scope" do
+      allow(api_instance).to receive(:get_principal_access).with(app_name).and_return(result)
+      expect(access_obj.accessible?(resource, 'read', app_name)).to be_truthy
+      expect(access_obj.group_scope?(resource, 'read')).to be_truthy
+    end
   end
 
-  it "collects scopes" do
-    allow(Insights::API::Common::RBAC::Service).to receive(:paginate).with(api_instance, :get_principal_access, opts, app_name).and_return([admin_scope, group_scope])
+  context "multiple scopes" do
+    let(:data) { [admin_scope, group_scope] }
+    it "collects scopes" do
+      allow(api_instance).to receive(:get_principal_access).with(app_name).and_return(result)
 
-    expect(access_obj.scopes(resource, 'read')).to match_array(%w(admin group))
+      expect(access_obj.scopes(resource, 'read')).to match_array(%w(admin group))
+    end
   end
 end


### PR DESCRIPTION
The RBAC team has changed the get_principal_access API to return all data in a single call and not use pagination. The data returned is still in the pagination format for backward compatibility

The old url used to look like
 **http://rbac.rbac-ci.svc:8080/api/rbac/v1/access/?application=\u0026limit=500\u0026offset=0**

The new URL without the limit and offset looks like

**http://rbac.rbac-ci.svc:8080/api/rbac/v1/access/?application=**

This change doesn't effect the catalog and approval services

The PR from the RBAC service that brought in this change is
https://github.com/RedHatInsights/insights-rbac/pull/195