### PR TITLE
Updated the support of association filter to expect operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The syntax for the _sort_by_ parameter is as follows:
 
 #### Filtering and Sorting by Association attribute
 
-Requests can also be filtered by assocation attribute and sorted by association attribute and count in addition to the direct attribute specified as in the above examples.
+Requests can also be filtered by assocation attribute and sorted by association attribute and count in addition to the direct attribute specified as in the above examples. When specifying attribute associations, the filter operators must be specified.
 
 Single level association can be specified as follows:
 
@@ -100,8 +100,8 @@ Single level association can be specified as follows:
 
 | Query Parameter | Ruby Client Parameter | GraphQL Parameter |
 | --------------- | --------------------- | ----------------- |
-| "?filter[association][name]=reviews" | { :filter => { :association => { :name => "reviews" } } } | filter: { association: { name: "reviews" } } |
 | "?filter[association][name][eq]=reviews" | { :filter => { :association => { :name => { :eq => "reviews" } } } } | filter: { association: { name: { eq: "reviews" } } } |
+| "?filter[source_type][name][eq][]=OpenStack&filter[source_type][name][eq][]=OpenShift" | { :filter => { :source_type => { :name => { :eq => [ "OpenStack", "OpenShift" ] } } } } | filter: { source_type: { name: { eq: [ "OpenStack", "OpenShift" ] } } } |
 
 ##### Sort by association attributes and count:
 

--- a/lib/insights/api/common/filter.rb
+++ b/lib/insights/api/common/filter.rb
@@ -72,7 +72,7 @@ module Insights
           filter.each do |ak, av|
             if av.kind_of?(Hash)
               av.each do |atk, atv|
-                if !ALL_COMPARISON_KEYWORDS.include?(atk)
+                if !ALL_COMPARISON_KEYWORDS.include?(atk) && atv.kind_of?(Hash)
                   result["#{ak}.#{atk}"] = atv
                 else
                   result[ak] = av

--- a/spec/lib/insights/api/common/filter_spec.rb
+++ b/spec/lib/insights/api/common/filter_spec.rb
@@ -1,8 +1,22 @@
 describe Insights::API::Common::Filter do
   context "compact_filter method" do
-    it "compacts association filter specifications of string" do
+    it "does not compact association filter of string values without operators" do
       parameters  = {"association" => {"attribute" => "value"}}
-      expectation = {"association.attribute" => "value"}
+      expectation = {"association" => {"attribute" => "value"}}
+
+      expect(described_class.compact_filter(parameters)).to(eq(expectation))
+    end
+
+    it "does not compact association filter of array values without operators" do
+      parameters  = {"association" => {"attribute" => ["value1", "value2"]}}
+      expectation = {"association" => {"attribute" => ["value1", "value2"]}}
+
+      expect(described_class.compact_filter(parameters)).to(eq(expectation))
+    end
+
+    it "compacts association filter specifications of string" do
+      parameters  = {"association" => {"attribute" => {"eq" => "value"}}}
+      expectation = {"association.attribute" => {"eq" => "value"}}
 
       expect(described_class.compact_filter(parameters)).to(eq(expectation))
     end


### PR DESCRIPTION
While this worked earlier, it was an ambiguous specification when no operators are present, i.e. filter[attr]=value case where eq is not specified.

- Updated the support of association filter so that specification of associations in filter requires the operator to be specified.
- Implied "eq" for values is no longer supported for associations, the "eq" operator should be specified.
- Updated README.md for additional examples.