### PR TITLE
Added args to the base_query call

### DIFF
--- a/lib/insights/api/common/graphql/templates/query_type.erb
+++ b/lib/insights/api/common/graphql/templates/query_type.erb
@@ -26,7 +26,7 @@ QueryType = ::GraphQL::ObjectType.define do
 
       resolve lambda { |_obj, args, ctx|
         if base_query.present?
-          scope = base_query.call(model_class, ctx)
+          scope = base_query.call(model_class, args, ctx)
         else
           scope = model_class
         end

--- a/spec/lib/insights/api/common/graphql/generator_spec.rb
+++ b/spec/lib/insights/api/common/graphql/generator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Insights::API::Common::GraphQL::Generator do
 
       schema_overlay = {
         "^source_types$" => {
-          "base_query" => lambda do |model_class, _ctx|
+          "base_query" => lambda do |model_class, _args, _ctx|
             model_class.where(:vendor => "redhat")
           end
         }
@@ -62,7 +62,7 @@ RSpec.describe Insights::API::Common::GraphQL::Generator do
 
       schema_overlay = {
         "^source_types$" => {
-          "base_query" => lambda do |model_class, _ctx|
+          "base_query" => lambda do |model_class, _args, _ctx|
             model_class.where(:vendor => "redhat")
           end
         }


### PR DESCRIPTION
To get the arguments coming into GraphQL the args needs to be passed down to the base_query for any apps that have a custom resolver.

**This is a breaking change.** 

We discovered this during testing for Approval Service, we needed the id of the object that the user is requesting. The graphql gem passes in an args parameter as the second parameter. As shown here and several other places in the gem.

https://github.com/rmosolgo/graphql-ruby/blob/73ac09cb95a0b03b3f00c09921b65534f66d0ae6/spec/fixtures/upgrader/starrable.original.rb#L31

There are currently 2 known repos using this  gem for which this will  be a breaking change 

https://github.com/RedHatInsights/approval-api/blob/830f34c87db22b513b70a301f1907e4d80b29270/app/controllers/api/v1x0/graphql_controller.rb#L19

https://github.com/RedHatInsights/catalog-api/blob/77a579df64add264d02ba840ff3c1fe7019db478/app/controllers/api/v1x0/graphql_controller.rb#L11

These repos might not have an issue

https://github.com/RedHatInsights/sources-api/blob/f8356e5f67e86f732b986a9697c707b388499fd7/app/controllers/api/v1/graphql_controller.rb#L7

https://github.com/RedHatInsights/topological_inventory-api/blob/6a265cbe2d4d3dbf7aa97b2511a3da9e0c96a29d/app/controllers/api/v1/graphql_controller.rb#L6

Sample Query that we were using  and we need to get the id => 48 which is in the args but wasn't being passed into the resolver.

```
{
  requests(id: "48") {
    id
    requests {
      id
      number_of_children
      decision
      description
      number_of_finished_children
      parent_id
      actions {
        id
        operation
        comments
        created_at
        processed_by
      }
    }
    number_of_children
    decision
    description
    number_of_finished_children
    parent_id
  }
}
```
