### PR TITLE
Use rack to get proper status code

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -11,7 +11,7 @@ module Insights
               errors = Insights::API::Common::ErrorDocument.new.tap do |error_document|
                 exception_list_from(exception).each do |exc|
                   code = exc.respond_to?(:code) ? exc.code : error_code_from_class(exc)
-                  error_document.add(code, "#{exc.class}: #{exc.message}")
+                  error_document.add(code.to_s, "#{exc.class}: #{exc.message}")
                 end
               end
 

--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -30,7 +30,7 @@ module Insights
 
           def error_code_from_class(exception)
             if ActionDispatch::ExceptionWrapper.rescue_responses.key?(exception.class.to_s)
-              ActionDispatch::ExceptionWrapper.rescue_responses[exception.class.to_s]
+              Rack::Utils.status_code(ActionDispatch::ExceptionWrapper.rescue_responses[exception.class.to_s])
             else
               DEFAULT_ERROR_CODE
             end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -66,6 +66,10 @@ module Api
       rescue ArgumentError
         raise SomethingHappened, "something else happened"
       end
+
+      def http_error
+        raise ActionCable::Connection::Authorization::UnauthorizedError
+      end
     end
 
     class GraphqlController < Api::V1::GraphqlController; end

--- a/spec/dummy/config/initializers/custom_exception_mappings.rb
+++ b/spec/dummy/config/initializers/custom_exception_mappings.rb
@@ -1,0 +1,3 @@
+ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
+  "ActionCable::Connection::Authorization::UnauthorizedError" => :forbidden
+)

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     namespace :v2x0, :path => "v2.0" do
       get "/error",        :to => "errors#error"
       get "/error_nested", :to => "errors#error_nested"
+      get "/http_error", :to => "errors#http_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :applications, :only => [:index]
@@ -26,6 +27,7 @@ Rails.application.routes.draw do
     namespace :v1x0, :path => "v1.0" do
       get "/error",        :to => "errors#error"
       get "/error_nested", :to => "errors#error_nested"
+      get "/http_error", :to => "errors#http_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :authentications, :only => [:create, :update]

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe("Insights::API::Common::Filter", :type => :request) do
     expect(response).to(
       have_attributes(
         :parsed_body => {
-          "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+          "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }
         },
         :status      => 400
       )

--- a/spec/requests/api/v2.0/paginated_response_spec.rb
+++ b/spec/requests/api/v2.0/paginated_response_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe("Insights::API::Common::PaginatedResponseV2", :type => :request) 
     expect(response).to(
       have_attributes(
         :parsed_body => {
-          "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+          "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }
         },
         :status      => 400
       )

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns the configured error" do
       get("/api/v1.0/error", :headers => headers)
 
-      expect(error.first["status"]).to eq "201"
+      expect(error.first["status"]).to eq 201
     end
   end
 end

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns a properly formatted error doc" do
       get("/api/v1.0/error", :headers => headers)
 
+      expect(response.status).to eq(400)
       expect(error.first["detail"]).to match(/StandardError/)
     end
   end
@@ -19,7 +20,8 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns a properly formatted error doc" do
       get("/api/v1.0/http_error", :headers => headers)
 
-      expect(error.first["status"]).to eq(403)
+      expect(response.status).to eq(403)
+      expect(error.first["status"]).to eq("403")
       expect(error.first["detail"]).to match(/UnauthorizedError/)
     end
   end
@@ -32,12 +34,13 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns a properly formatted error doc" do
       expected_response = {
         "errors" => [
-          {"status" => 200, "detail" => "Api::V1x0::ErrorsController::SomethingHappened: something else happened"},
-          {"status" => 400, "detail" => "ArgumentError: something happened"}
+          {"status" => "200", "detail" => "Api::V1x0::ErrorsController::SomethingHappened: something else happened"},
+          {"status" => "400", "detail" => "ArgumentError: something happened"}
         ]
       }
 
       expect(JSON.parse(response.body)).to eq expected_response
+      expect(response.status).to eq(200)
     end
 
     it "uses the last response code as the status" do
@@ -52,7 +55,8 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns the configured error" do
       get("/api/v1.0/error", :headers => headers)
 
-      expect(error.first["status"]).to eq 201
+      expect(error.first["status"]).to eq "201"
+      expect(response.status).to eq(201)
     end
   end
 end

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -15,6 +15,15 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     end
   end
 
+  context "when there is only one http exception" do
+    it "returns a properly formatted error doc" do
+      get("/api/v1.0/http_error", :headers => headers)
+
+      expect(error.first["status"]).to eq(403)
+      expect(error.first["detail"]).to match(/UnauthorizedError/)
+    end
+  end
+
   context "when there are multiple exceptions" do
     before do
       get("/api/v1.0/error_nested", :headers => headers)

--- a/spec/requests/request_body_validation_spec.rb
+++ b/spec/requests/request_body_validation_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Insights::API::Common::ApplicationController Body", :type => :re
     post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("garbage" => "abc"))
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: garbage", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: garbage", "status" => "400"}])
   end
 
   it "permitted key, good value" do
@@ -32,7 +32,7 @@ RSpec.describe "Insights::API::Common::ApplicationController Body", :type => :re
     post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("username" => 1))
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/username expected string, but received Integer: 1", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/username expected string, but received Integer: 1", "status" => "400"}])
   end
 
   it "patch, permitted key, array" do
@@ -76,13 +76,13 @@ RSpec.describe "Insights::API::Common::ApplicationController Body", :type => :re
     post("/api/v1.0/authentications", :headers => headers, :params => {"username" => "abc"})
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistRequiredKey: #/components/schemas/Authentication missing required parameters: authtype", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistRequiredKey: #/components/schemas/Authentication missing required parameters: authtype", "status" => "400"}])
   end
 
   it "empty body" do
     post("/api/v1.0/authentications", :headers => headers)
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistRequiredKey: #/components/schemas/Authentication missing required parameters: authtype", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "OpenAPIParser::NotExistRequiredKey: #/components/schemas/Authentication missing required parameters: authtype", "status" => "400"}])
   end
 end

--- a/spec/requests/request_path_spec.rb
+++ b/spec/requests/request_path_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe "Insights::API::Common::ApplicationController Request path", :typ
     get("/api/v1.0/vms/abc", :headers => headers)
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}])
   end
 
   it "invalid ID (mixed integer and string characters)" do
     get("/api/v1.0/vms/123abc", :headers => headers)
 
     expect(response.status).to eq(400)
-    expect(response.parsed_body).to eq("errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => 400}])
+    expect(response.parsed_body).to eq("errors" => [{"detail" => "Insights::API::Common::ApplicationControllerMixins::RequestPath::RequestPathError: ID is invalid", "status" => "400"}])
   end
 end


### PR DESCRIPTION
Fixes #178
Uses Rack::Utils.status_code to convert the Rails HTTP error symbols to
numeric values. The status_code can handle integers/strings/symbols and
returns the appropriate numeric value
e.g.

Rack::Utils.status_code(400) => 400
Rack::Utils.status_code("400") => 400
Rack::Utils.status_code(:forbidden) => 403


The JSON API Error Object Sample
https://jsonapi.org/examples/#error-objects-basics

The status value should be
https://jsonapi.org/format/#errors
status: the HTTP status code applicable to this problem, expressed as a string value.

