### PR TITLE
Percolate errors from different micro services

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -46,7 +46,7 @@ module Insights
 
           def api_client_errors(exc, error_document)
             body = JSON.parse(exc.response_body)
-            if body.key?('errors') && body['errors'].is_a?(Array)
+            if body.is_a?(Hash) && body.key?('errors') && body['errors'].is_a?(Array)
               body['errors'].each do |error|
                 next unless error.key?('status') && error.key?('detail')
 

--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -40,7 +40,8 @@ module Insights
           end
 
           def api_client_exception?(exc)
-            exc.respond_to?(:code) && exc.respond_to?(:response_body) && exc.respond_to?(:response_headers)
+            exc.respond_to?(:code) && exc.respond_to?(:response_body) && exc.respond_to?(:response_headers) &&
+              !exc.response_body.nil?
           end
 
           def api_client_errors(exc, error_document)

--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -53,7 +53,7 @@ module Insights
                 error_document.add(error['status'], error['detail'])
               end
             else
-              error_document.add(exc.code, exc.message )
+              error_document.add(exc.code.to_s, exc.message )
             end
           end
         end

--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -10,8 +10,11 @@ module Insights
               logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}")
               errors = Insights::API::Common::ErrorDocument.new.tap do |error_document|
                 exception_list_from(exception).each do |exc|
-                  code = exc.respond_to?(:code) ? exc.code : error_code_from_class(exc)
-                  error_document.add(code.to_s, "#{exc.class}: #{exc.message}")
+                  if api_client_exception?(exc)
+                    api_client_errors(exc, error_document)
+                  else
+                    error_document.add(error_code_from_class(exc).to_s, "#{exc.class}: #{exc.message}")
+                  end
                 end
               end
 
@@ -33,6 +36,23 @@ module Insights
               Rack::Utils.status_code(ActionDispatch::ExceptionWrapper.rescue_responses[exception.class.to_s])
             else
               DEFAULT_ERROR_CODE
+            end
+          end
+
+          def api_client_exception?(exc)
+            exc.respond_to?(:code) && exc.respond_to?(:response_body) && exc.respond_to?(:response_headers)
+          end
+
+          def api_client_errors(exc, error_document)
+            body = JSON.parse(exc.response_body)
+            if body.key?('errors') && body['errors'].is_a?(Array)
+              body['errors'].each do |error|
+                next unless error.key?('status') && error.key?('detail')
+
+                error_document.add(error['status'], error['detail'])
+              end
+            else
+              error_document.add(exc.code, exc.message )
             end
           end
         end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -72,10 +72,7 @@ module Api
       end
 
       def api_client_error
-        require 'json'
-        data = [{'status' => '400', 'detail' => 'A very bad request'},
-                {'status' => '404', 'detail' => 'Buzz is missing'}]
-        raise ApiClientError.new(:code => '400', :response_headers => {}, :response_body => {'errors' => data}.to_json)
+        raise ApiClientError.new
       end
     end
 

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -70,6 +70,13 @@ module Api
       def http_error
         raise ActionCable::Connection::Authorization::UnauthorizedError
       end
+
+      def api_client_error
+        require 'json'
+        data = [{'status' => '400', 'detail' => 'A very bad request'},
+                {'status' => '404', 'detail' => 'Buzz is missing'}]
+        raise ApiClientError.new(:code => '400', :response_headers => {}, :response_body => {'errors' => data}.to_json)
+      end
     end
 
     class GraphqlController < Api::V1::GraphqlController; end

--- a/spec/dummy/app/controllers/api_client_error.rb
+++ b/spec/dummy/app/controllers/api_client_error.rb
@@ -1,0 +1,43 @@
+class ApiClientError < StandardError
+  attr_reader :code, :response_headers, :response_body
+
+  # Usage examples:
+  #   ApiClientError.new
+  #   ApiClientError.new("message")
+  #   ApiClientError.new(:code => 500, :response_headers => {}, :response_body => "")
+  #   ApiClientError.new(:code => 404, :message => "Not Found")
+  def initialize(arg = nil)
+    if arg.is_a? Hash
+      if arg.key?(:message) || arg.key?('message')
+        super(arg[:message] || arg['message'])
+      else
+        super arg
+      end
+
+      arg.each do |k, v|
+        instance_variable_set "@#{k}", v
+      end
+    else
+      super arg
+    end
+  end
+
+  # Override to_s to display a friendly error message
+  def to_s
+    message
+  end
+
+  def message
+    if @message.nil?
+      msg = "Error message: the server returns an error"
+    else
+      msg = @message
+    end
+
+    msg += "\nHTTP status code: #{code}" if code
+    msg += "\nResponse headers: #{response_headers}" if response_headers
+    msg += "\nResponse body: #{response_body}" if response_body
+
+    msg
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       get "/error",        :to => "errors#error"
       get "/error_nested", :to => "errors#error_nested"
       get "/http_error", :to => "errors#http_error"
+      get "/api_client_error", :to => "errors#api_client_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :applications, :only => [:index]
@@ -28,6 +29,7 @@ Rails.application.routes.draw do
       get "/error",        :to => "errors#error"
       get "/error_nested", :to => "errors#error_nested"
       get "/http_error", :to => "errors#http_error"
+      get "/api_client_error", :to => "errors#api_client_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :authentications, :only => [:create, :update]

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     end
   end
 
+  context "api_client_error" do
+    it "returns a properly formatted error doc" do
+      get("/api/v1.0/api_client_error", :headers => headers)
+
+      expect(error.count).to eq(2)
+      expect(error.first['status']).to eq('400')
+      expect(error.second['status']).to eq('404')
+      expect(error.first['detail']).to eq('A very bad request')
+      expect(error.second['detail']).to eq('Buzz is missing')
+    end
+  end
+
   context "when there are multiple exceptions" do
     before do
       get("/api/v1.0/error_nested", :headers => headers)

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -27,14 +27,44 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
   end
 
   context "api_client_error" do
-    it "returns a properly formatted error doc" do
-      get("/api/v1.0/api_client_error", :headers => headers)
+    context "with response body" do
+      let(:response_header) { { 'Content-Type' => 'application/json' } }
+      let(:api_client_exception) do
+        ApiClientError.new(:code            => 200,
+                           :response_body   => response_body.to_json,
+                           :response_header => response_header)
+      end
+      let(:response_body) do 
+        {'errors' => [{'status' => '400', 'detail' => 'Sherrif Woody rejects rescue mission'},
+                      {'status' => '404', 'detail' => 'Buzz is missing'}]}
+      end
 
-      expect(error.count).to eq(2)
-      expect(error.first['status']).to eq('400')
-      expect(error.second['status']).to eq('404')
-      expect(error.first['detail']).to eq('A very bad request')
-      expect(error.second['detail']).to eq('Buzz is missing')
+      before do
+        allow(ApiClientError).to receive(:new).and_return(api_client_exception)
+      end
+      it "returns a properly formatted error doc" do
+        get("/api/v1.0/api_client_error", :headers => headers)
+
+        expect(error.count).to eq(2)
+        expect(error.first['status']).to eq('400')
+        expect(error.second['status']).to eq('404')
+        expect(error.first['detail']).to eq('Sherrif Woody rejects rescue mission')
+        expect(error.second['detail']).to eq('Buzz is missing')
+      end
+    end
+
+    context "no response body" do
+      let(:api_client_exception) { ApiClientError.new(:message => 'test') }
+      before do
+        allow(ApiClientError).to receive(:new).and_return(api_client_exception)
+      end
+      it "returns a formatted error doc with classname" do
+        get("/api/v1.0/api_client_error", :headers => headers)
+
+        expect(error.count).to eq(1)
+        expect(error.first['status']).to eq('400')
+        expect(error.first['detail']).to eq("ApiClientError: test")
+      end
     end
   end
 

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
       end
     end
 
+    context "with invalid response body" do
+      let(:response_header) { { 'Content-Type' => 'application/json' } }
+      let(:api_client_exception) do
+        ApiClientError.new(:code            => 503,
+                           :response_body   => response_body.to_json,
+                           :response_header => response_header)
+      end
+      let(:response_body) { 'fred' }
+
+      before do
+        allow(ApiClientError).to receive(:new).and_return(api_client_exception)
+      end
+      it "returns a properly formatted error doc" do
+        get("/api/v1.0/api_client_error", :headers => headers)
+
+        expect(error.count).to eq(1)
+        expect(error.first['status']).to eq('503')
+        expect(error.first['detail']).to match(/Error message/)
+      end
+    end
+
     context "no response body" do
       let(:api_client_exception) { ApiClientError.new(:message => 'test') }
       before do


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/SSP-1437

Since Catalog interacts with multiple micro services, RBAC, Approval,
Topology etc, we need to percolate errors from the other services upto
the caller. Since the IPP recommends using JSON-API's error format which
is an array of error objects. This PR handles errors coming from
openapi-generated clients and converts them into error objects.
<img width="699" alt="Screen Shot 2020-04-14 at 6 15 06 PM" src="https://user-images.githubusercontent.com/6452699/79279810-dd2d4f00-7e7c-11ea-9293-6904b643e722.png">
