### PR TITLE
ManangeIQ Logger is deprecating the use of current_request

### DIFF
--- a/lib/insights/api/common/request.rb
+++ b/lib/insights/api/common/request.rb
@@ -25,6 +25,14 @@ module Insights
           Thread.current[:current_request]
         end
 
+        def self.current_request_id
+          Thread.current[:request_id]
+        end
+
+        def self.current_request_id=(id)
+          Thread.current[:request_id] = id
+        end
+
         def self.current!
           current || raise(RequestNotSet)
         end
@@ -45,10 +53,13 @@ module Insights
 
         def self.with_request(request)
           saved = current
+          saved_request_id = current&.request_id
           self.current = request
+          self.current_request_id = current&.request_id
           yield current
         ensure
           self.current = saved
+          self.current_request_id = saved_request_id
         end
 
         def self.current_forwardable

--- a/spec/lib/insights/api/common/request_spec.rb
+++ b/spec/lib/insights/api/common/request_spec.rb
@@ -4,6 +4,8 @@ describe Insights::API::Common::Request do
     ActionDispatch::Request.new(headers)
   end
 
+  let(:x_rh_insights_request_id) { "01234567-89ab-cdef-0123-456789abcde" }
+
   let(:request_bad) do
     {
       :headers      => { 'blah' => 'blah' },
@@ -21,7 +23,7 @@ describe Insights::API::Common::Request do
   let(:forwardable_good) do
     {
       'x-rh-identity'            => encoded_user_hash,
-      'x-rh-insights-request-id' => "01234567-89ab-cdef-0123-456789abcde",
+      'x-rh-insights-request-id' => x_rh_insights_request_id
     }
   end
 
@@ -35,6 +37,10 @@ describe Insights::API::Common::Request do
 
     it "#original_url" do
       expect(@instance.original_url).to eq "https://example.com"
+    end
+
+    it ".current_request_id" do
+      expect(described_class.current_request_id).to eq x_rh_insights_request_id
     end
 
     describe "#headers" do
@@ -72,7 +78,7 @@ describe Insights::API::Common::Request do
     end
 
     it "#request_id" do
-      expect(@instance.request_id).to eq "01234567-89ab-cdef-0123-456789abcde"
+      expect(@instance.request_id).to eq x_rh_insights_request_id
     end
 
     it "#identity" do
@@ -103,6 +109,10 @@ describe Insights::API::Common::Request do
     it "#request_id" do
       expect(@instance.request_id).to be_nil
     end
+
+    it ".current_request_id" do
+      expect(described_class.current_request_id).to be_nil
+    end
   end
 
 
@@ -111,7 +121,7 @@ describe Insights::API::Common::Request do
       {
         :headers      => {
           'x-rh-identity'            => encoded_system_hash,
-          'x-rh-insights-request-id' => "01234567-89ab-cdef-0123-456789abcde",
+          'x-rh-insights-request-id' => x_rh_insights_request_id
         },
         :original_url => 'https://example.com'
       }
@@ -155,7 +165,7 @@ describe Insights::API::Common::Request do
     end
 
     it "#request_id" do
-      expect(@instance.request_id).to eq "01234567-89ab-cdef-0123-456789abcde"
+      expect(@instance.request_id).to eq x_rh_insights_request_id
     end
 
     it "#identity" do


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-loggers/blob/7e6d3c29b94bb4b73536c4431fb60ebba9aae9db/lib/manageiq/loggers/container.rb#L68

Added class methods to set the request_id to be compatible with
the manageiq logger