### PR TITLE
Add support for custom prometheus metrics defined by the application

### DIFF
--- a/spec/lib/insights/api/common/metrics_spec.rb
+++ b/spec/lib/insights/api/common/metrics_spec.rb
@@ -1,0 +1,44 @@
+describe Insights::API::Common::Metrics do
+  let(:custom_metrics) do
+    {
+      :custom_metrics => [
+        {
+          :name      => "message_on_queue",
+          :type        => :counter,
+          :description => "total number of messages put on the queue"
+        },
+        {
+          :name      => "error_processing_payload",
+          :type        => :counter,
+          :description => "total number of errors while attempting to messages put on the queue"
+        }
+      ]
+    }
+  end
+
+  let(:metrics) { Insights::API::Common::Metrics }
+  let(:prometheus) { PrometheusExporter::Client.default }
+
+  before do
+    # Dummy app doesn't listen here.
+    allow(Rails).to receive_message_chain(:application, :middleware, :unshift)
+
+    metrics.activate(nil, "dummy_prefix", custom_metrics)
+  end
+
+  describe ".setup_custom_metrics" do
+    it "creates the singleton methods on the Metrics object" do
+      expect(metrics.respond_to?(:message_on_queue)).to be_truthy
+      expect(metrics.respond_to?(:error_processing_payload)).to be_truthy
+    end
+
+    it "adds instance vars to track the counts on the Metrics object" do
+      expect(metrics.instance_values.keys).to match_array %w[message_on_queue_counter error_processing_payload_counter]
+    end
+
+    it "adds the metrics defined in the hash" do
+      expect(prometheus.instance_values["metrics"].map(&:name).uniq.count).to eq 2
+      expect(prometheus.instance_values["metrics"].map(&:type).uniq).to match_array %I[counter]
+    end
+  end
+end


### PR DESCRIPTION
This is for https://github.com/RedHatInsights/topological_inventory-ingress_api/pull/87 and potentially other applications that are currently using the Common Metrics classes. 

Basically it allows passing in a hash defined by the application to register prometheus metrics and make helper methods for them as specified.

First pass only supports counters, but maybe I'll implement support for histograms etc in the future. 

example implementation: https://github.com/RedHatInsights/topological_inventory-ingress_api/pull/87

\# TODO:
- [x] specs