### PR TITLE
Handle Pundit::NotAuthorizedError exceptions differently than general exceptions

### DIFF
--- a/lib/insights/api/common.rb
+++ b/lib/insights/api/common.rb
@@ -1,3 +1,4 @@
+require "insights/api/common/custom_exceptions"
 require "insights/api/common/engine"
 require "insights/api/common/entitlement"
 require "insights/api/common/error_document"

--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -7,19 +7,25 @@ module Insights
 
           def self.included(other)
             other.rescue_from(StandardError, RuntimeError) do |exception|
-              logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}")
-              errors = Insights::API::Common::ErrorDocument.new.tap do |error_document|
-                exception_list_from(exception).each do |exc|
-                  if api_client_exception?(exc)
-                    api_client_errors(exc, error_document)
-                  else
-                    error_document.add(error_code_from_class(exc).to_s, "#{exc.class}: #{exc.message}")
-                  end
+              rescue_from_handler(exception) do |error_document, exc|
+                error_document.add(error_code_from_class(exc).to_s, "#{exc.class}: #{exc.message}")
+              end
+            end
+          end
+
+          def rescue_from_handler(exception)
+            logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}")
+            errors = Insights::API::Common::ErrorDocument.new.tap do |error_document|
+              exception_list_from(exception).each do |exc|
+                if api_client_exception?(exc)
+                  api_client_errors(exc, error_document)
+                else
+                  yield error_document, exc
                 end
               end
-
-              render :json => errors.to_h, :status => error_code_from_class(exception)
             end
+
+            render :json => errors.to_h, :status => error_code_from_class(exception)
           end
 
           def exception_list_from(exception)

--- a/lib/insights/api/common/custom_exceptions.rb
+++ b/lib/insights/api/common/custom_exceptions.rb
@@ -1,0 +1,16 @@
+module Insights
+  module API
+    module Common
+      class CustomExceptions
+        CUSTOM_EXCEPTION_LIST = %w[Pundit::NotAuthorizedError].freeze
+
+        def self.custom_message(exception)
+          case exception.class.to_s
+          when "Pundit::NotAuthorizedError"
+            "You are not authorized to #{exception.query.delete_suffix('?')} this #{exception.record.model_name.human.downcase}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -74,10 +74,25 @@ module Api
       def api_client_error
         raise ApiClientError.new
       end
+
+      def pundit_error
+        raise Pundit::NotAuthorizedError.new("create?", SourceType)
+      end
     end
 
     class GraphqlController < Api::V1::GraphqlController; end
     class SourcesController < Api::V1::SourcesController; end
     class SourceTypesController < Api::V1::SourceTypesController; end
+  end
+end
+
+module Pundit
+  class NotAuthorizedError < StandardError
+    attr_accessor :query, :record
+
+    def initialize(query, record)
+      @query = query
+      @record = record
+    end
   end
 end

--- a/spec/dummy/config/initializers/custom_exception_mappings.rb
+++ b/spec/dummy/config/initializers/custom_exception_mappings.rb
@@ -1,3 +1,4 @@
 ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
-  "ActionCable::Connection::Authorization::UnauthorizedError" => :forbidden
+  "ActionCable::Connection::Authorization::UnauthorizedError" => :forbidden,
+  "Pundit::NotAuthorizedError"                                => :forbidden
 )

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       get "/error_nested", :to => "errors#error_nested"
       get "/http_error", :to => "errors#http_error"
       get "/api_client_error", :to => "errors#api_client_error"
+      get "/pundit_error", :to => "errors#pundit_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :applications, :only => [:index]
@@ -30,6 +31,7 @@ Rails.application.routes.draw do
       get "/error_nested", :to => "errors#error_nested"
       get "/http_error", :to => "errors#http_error"
       get "/api_client_error", :to => "errors#api_client_error"
+      get "/pundit_error", :to => "errors#pundit_error"
       get "/openapi.json", :to => "root#openapi"
       post "graphql" => "graphql#query"
       resources :authentications, :only => [:create, :update]

--- a/spec/lib/insights/api/common/custom_exceptions_spec.rb
+++ b/spec/lib/insights/api/common/custom_exceptions_spec.rb
@@ -1,0 +1,14 @@
+describe Insights::API::Common::CustomExceptions do
+  describe ".custom_message" do
+    context "when the exception is a Pundit::NotAuthorizedError" do
+      let(:record) { SourceType.new }
+      let(:exception) { double(:class => "Pundit::NotAuthorizedError", :query => "create?", :record => record) }
+
+      it "returns a customized message" do
+        expect(Insights::API::Common::CustomExceptions.custom_message(exception)).to eq(
+          "You are not authorized to create this source type"
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     end
   end
 
+  context "pundit error" do
+    it "returns a customized error message" do
+      get("/api/v1.0/pundit_error", :headers => headers)
+      expect(response.status).to eq(403)
+      expect(error.first["detail"]).to match(/You are not authorized to create this source type/)
+    end
+  end
+
   context "api_client_error" do
     context "with response body" do
       let(:response_header) { { 'Content-Type' => 'application/json' } }


### PR DESCRIPTION
In Catalog, we have an error that is being raised by a gem automatically, `Pundit::NotAuthorizedError`, which also auto-generates a not-so-user-friendly error message of `"not authorized to <action?> this Class"`.

We needed a way to hook into the `rescue_from` process without duplicating the code in common, so I broke out the handler into a separate method and I'm using it to pass control over the error message to the `rescue_from` we have for specifically handling `Pundit::NotAuthorizedError`s.

Example usage: [Catalog PR](https://github.com/RedHatInsights/catalog-api/pull/731).

Edit: I still broke out the handling code into a `rescue_from_handler` since it was a simple refactor and it allows us to potentially use it going forward, but we are not currently using it. Instead, common is just going to attempt to handle any Pundit::NotAuthorizedError exception similar to how it branches when handling api client errors.