### PR TITLE
Handle scenarios where response body contains unparseable JSON

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -45,7 +45,7 @@ module Insights
           end
 
           def api_client_errors(exc, error_document)
-            body = JSON.parse(exc.response_body)
+            body = json_parsed_body(exc)
             if body.is_a?(Hash) && body.key?('errors') && body['errors'].is_a?(Array)
               body['errors'].each do |error|
                 next unless error.key?('status') && error.key?('detail')
@@ -55,6 +55,12 @@ module Insights
             else
               error_document.add(exc.code.to_s, exc.message )
             end
+          end
+
+          def json_parsed_body(exc)
+            JSON.parse(exc.response_body)
+          rescue StandardError
+            nil
           end
         end
       end

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
       let(:response_header) { { 'Content-Type' => 'application/json' } }
       let(:api_client_exception) do
         ApiClientError.new(:code            => 503,
-                           :response_body   => response_body.to_json,
+                           :response_body   => response_body,
                            :response_header => response_header)
       end
-      let(:response_body) { 'fred' }
+      let(:response_body) { "@" }
 
       before do
         allow(ApiClientError).to receive(:new).and_return(api_client_exception)


### PR DESCRIPTION
If the response body contains an invalid JSON we should not raise an exception. Usually happens if the server ran into some error and couldn't send back a valid response body. These are typically the 5xx errors, server side errors.

e.g this is live data that came back from the RBAC service

```
{"@timestamp":"2020-05-07T08:52:38.780751 ","hostname":"catalog-api-89-46qw4","pid":27,"tid":"2ad1404721ec","level":"err","message":"RBACApiClient::ApiError: Error message: the server returns an error\nHTTP status code: 500\nResponse headers: {\"Server\"=\u003e\"gunicorn/19.9.0\", \"Date\"      =\u003e\"Thu, 07 May 2020 08:52:38 GMT\", \"Connection\"=\u003e\"keep-alive\", \"Content-Type\"=\u003e\"text/html\", \"Content-Length\"=\u003e\"2      7\", \"Vary\"=\u003e\"Origin\"}\nResponse body: \u003ch1\u003eServer Error (500)\u003c/h1\u003e ","request_id":"e2a456005ece40209f01ef5abb5a40de"
```

```
{"@timestamp":"2020-05-07T08:52:38.803570 ","hostname":"catalog-api-89-46qw4","pid":27,"tid":"2ad1404721ec","level":"crit","message":"JSON::ParserError (783: unexpected token at '\u003ch1\u003eServer Error (500)\u003c/h1\u003e'):"}
```