### PR TITLE
The status field in the error object is string

### DIFF
--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -117,8 +117,8 @@ module Insights
                     "type"        => "object",
                     "properties"  => {
                       "status"    => {
-                        "type"    => "integer",
-                        "example" => 404
+                        "type"    => "string",
+                        "example" => "404"
                       },
                       "detail"    => {
                         "type"    => "string",


### PR DESCRIPTION
To conform with the IPP and the JSON API error object format
the generator should be using string for status.

https://jsonapi.org/format/#errors

This PR updates the pre-canned type used by the generator used by topology and sources when they generate the openapi.json so it can create the JSON API conformant type.

https://github.com/RedHatInsights/sources-api/blob/8782d2103bed61c40b547603089c0978624950e1/public/doc/openapi-3-v3.0.json#L1780