### PR TITLE
Switched to insights-rbac-api-client from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,4 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Declare your gem's dependencies in topological_inventory.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
-gem 'rbac-api-client', :git => "https://github.com/RedHatInsights/insights-rbac-api-client-ruby", :branch => "master"
-
 gemspec

--- a/insights-api-common.gemspec
+++ b/insights-api-common.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "more_core_extensions"
   spec.add_runtime_dependency "openapi_parser",      "~> 0.10.0"
 
+  spec.add_runtime_dependency "insights-rbac-api-client", "~> 1.0"
   # For Insights::API::Common::GraphQL
   spec.add_runtime_dependency "graphql",         "~> 1.9"
   spec.add_runtime_dependency "graphql-batch",   "~> 0.4"

--- a/lib/insights/api/common/rbac/seed.rb
+++ b/lib/insights/api/common/rbac/seed.rb
@@ -2,7 +2,7 @@ module Insights
   module API
     module Common
       module RBAC
-        require 'rbac-api-client'
+        require 'insights-rbac-api-client'
 
         class Seed
           def initialize(seed_file, user_file = nil)

--- a/lib/insights/api/common/rbac/service.rb
+++ b/lib/insights/api/common/rbac/service.rb
@@ -2,7 +2,7 @@ module Insights
   module API
     module Common
       module RBAC
-        require 'rbac-api-client'
+        require 'insights-rbac-api-client'
 
         class NetworkError  < StandardError; end
         class TimedOutError < StandardError; end


### PR DESCRIPTION
Previously we were directly pointing to a git branch,
switching to use the new renamed gem from rubygems.org

Dependent on PR https://github.com/RedHatInsights/insights-rbac-api-client-ruby/pull/10