### PR TITLE
Add the ability to disable metrics by setting METRICS_PORT=0

### DIFF
--- a/lib/insights/api/common/metrics.rb
+++ b/lib/insights/api/common/metrics.rb
@@ -6,6 +6,8 @@ module Insights
           require 'prometheus_exporter'
           require 'prometheus_exporter/client'
 
+          return if metrics_port == 0
+
           ensure_exporter_server
           enable_in_process_metrics
           enable_web_server_metrics(prefix)
@@ -14,10 +16,10 @@ module Insights
 
         private_class_method def self.ensure_exporter_server
           require 'socket'
-          TCPSocket.open("localhost", 9394) {}
+          TCPSocket.open("localhost", metrics_port) {}
         rescue Errno::ECONNREFUSED
           require 'prometheus_exporter/server'
-          server = PrometheusExporter::Server::WebServer.new(port: 9394)
+          server = PrometheusExporter::Server::WebServer.new(port: metrics_port)
           server.start
 
           PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
@@ -50,6 +52,10 @@ module Insights
               end
             end
           end
+        end
+
+        private_class_method def self.metrics_port
+          @metrics_port ||= (ENV['METRICS_PORT']&.to_i || 9394)
         end
       end
     end

--- a/spec/lib/insights/api/common/metrics_spec.rb
+++ b/spec/lib/insights/api/common/metrics_spec.rb
@@ -33,7 +33,7 @@ describe Insights::API::Common::Metrics do
     end
 
     it "adds instance vars to track the counts on the Metrics object" do
-      expect(metrics.instance_values.keys).to match_array %w[message_on_queue_counter error_processing_payload_counter]
+      expect(metrics.instance_values.keys).to match_array %w[message_on_queue_counter error_processing_payload_counter metrics_port]
     end
 
     it "adds the metrics defined in the hash" do


### PR DESCRIPTION
Found out that we can't really disable these metrics, so we run into issues with multiple common-enabled apps that can't bind to the same port if running on localhost. 

This allows for disabling or setting a different port number if you really want the metrics. 