### PR TITLE
Add github workflow to release to rubygems automatically

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,50 @@
+name: Release Ruby Gem
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+    - 'lib/insights/api/common/version.rb'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+
+    - name: Read the version.rb
+      id: version_file
+      run: |
+        echo ::set-output name=data::$(grep VERSION lib/insights/api/common/version.rb | awk {'print $3'} | tr -d '"')
+
+    - name: Echo the gem version
+      run: |
+        echo "v${{ steps.version_file.outputs.data }}"
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: "v${{ steps.version_file.outputs.data }}"
+        release_name: "v${{ steps.version_file.outputs.data }}"
+


### PR DESCRIPTION
https://github.com/marketplace/actions/publish-to-rubygems

Uses that action, which just runs `rake release` at the project root, we just need two secrets:
- `GITHUB_TOKEN`
- `RUBYGEMS_API_KEY`

cc @gmcculloug @syncrou @slemrmartin 