### PR TITLE
Add openapi-validator.sh script for reference from API repos.

### DIFF
--- a/.travis_scripts/openapi-validator.sh
+++ b/.travis_scripts/openapi-validator.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+set -o pipefail
+
+if ! ver=$(./openapi-generator-cli version | tail -1); then
+  ver="4.3.1"  
+  echo "Use default version ${ver} to validate"
+fi
+
+for entry in ./public/doc/openapi-3-v*.json
+do
+  OPENAPI_GENERATOR_VERSION=${ver} ./openapi-generator-cli validate -i "$entry"
+done


### PR DESCRIPTION
Part of fixing #201

Move the `openapi-validator.sh` script to a common location for all the API repos to access.