### PR TITLE
Add download of openapi-generator script

### DIFF
--- a/.travis_scripts/openapi-validator.sh
+++ b/.travis_scripts/openapi-validator.sh
@@ -2,6 +2,10 @@
 set -eu
 set -o pipefail
 
+curl -L https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh > ./openapi-generator-cli
+chmod +x ./openapi-generator-cli
+echo "openapi-generator-cli successfully downloaded"
+
 if ! ver=$(./openapi-generator-cli version | tail -1); then
   ver="4.3.1"  
   echo "Use default version ${ver} to validate"


### PR DESCRIPTION
After spending some time with other travis scripts I started thinking it would be better to move the download of `openapi-generator-cli` to this common method instead of requiring each caller to have to download it separately as part of the `.travis.yaml`

It's not a big impact here (2 new lines), but the caller's `.travis.yml` file can be reduced to one line:
```diff
- - curl -L https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh
-   > ./openapi-generator-cli
- - chmod +x ./openapi-generator-cli
- - curl -L https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.travis_scripts/openapi-validator.sh
-   > ./openapi-validator.sh
- - chmod +x ./openapi-validator.sh
- - ./openapi-validator.sh
+ - curl -sSL https://raw.githubusercontent.com/gmcculloug/insights-api-common-rails/master/.travis_scripts/openapi-validator.sh | bash -s
```

If you like this approach it can be merged ahead of updating the callers to use the 1-line call.