### PR TITLE
Make sure Pundit exception's query type is String

### DIFF
--- a/lib/insights/api/common/custom_exceptions.rb
+++ b/lib/insights/api/common/custom_exceptions.rb
@@ -7,7 +7,7 @@ module Insights
         def self.custom_message(exception)
           case exception.class.to_s
           when "Pundit::NotAuthorizedError"
-            "You are not authorized to #{exception.query.delete_suffix('?')} this #{exception.record.model_name.human.downcase}"
+            "You are not authorized to #{exception.query.to_s.delete_suffix('?')} this #{exception.record.model_name.human.downcase}"
           end
         end
       end

--- a/spec/lib/insights/api/common/custom_exceptions_spec.rb
+++ b/spec/lib/insights/api/common/custom_exceptions_spec.rb
@@ -1,14 +1,26 @@
 describe Insights::API::Common::CustomExceptions do
-  describe ".custom_message" do
-    context "when the exception is a Pundit::NotAuthorizedError" do
-      let(:record) { SourceType.new }
-      let(:exception) { double(:class => "Pundit::NotAuthorizedError", :query => "create?", :record => record) }
+  describe ".custom_message with Pundit::NotAuthorizedError exception" do
+    let(:record) { SourceType.new }
+    let(:exception) { double(:class => "Pundit::NotAuthorizedError", :query => query, :record => record) }
 
+    shared_examples_for "#test_message" do
       it "returns a customized message" do
         expect(Insights::API::Common::CustomExceptions.custom_message(exception)).to eq(
           "You are not authorized to create this source type"
         )
       end
+    end
+
+    context "when the query is String" do
+      let(:query) { "create?" }
+
+      it_behaves_like "#test_message"
+    end
+
+    context "when the query is Symbol" do
+      let(:query) { :create? }
+
+      it_behaves_like "#test_message"
     end
   end
 end


### PR DESCRIPTION
This PR allows `authorize` to accept symbol as its second parameter, like `authorized(Portfolio, :update?)`, otherwise following `delete_suffix` will fail and raise other exceptions.