### PR TITLE
Fixed to log error messages in with_request block

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/exception_handling.rb
+++ b/lib/insights/api/common/application_controller_mixins/exception_handling.rb
@@ -14,7 +14,6 @@ module Insights
           end
 
           def rescue_from_handler(exception)
-            logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}")
             errors = Insights::API::Common::ErrorDocument.new.tap do |error_document|
               exception_list_from(exception).each do |exc|
                 if api_client_exception?(exc)

--- a/lib/insights/api/common/request.rb
+++ b/lib/insights/api/common/request.rb
@@ -57,6 +57,9 @@ module Insights
           self.current = request
           self.current_request_id = current&.request_id
           yield current
+        rescue => exception
+          Rails.logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}")
+          raise
         ensure
           self.current = saved
           self.current_request_id = saved_request_id

--- a/spec/lib/insights/api/common/request_spec.rb
+++ b/spec/lib/insights/api/common/request_spec.rb
@@ -200,6 +200,8 @@ describe Insights::API::Common::Request do
     end
 
     it 'with an invalid Hash' do
+      expect(Rails.logger).to receive(:error).with(/ArgumentError: /).once
+
       expect do
         described_class.with_request({}) {}
       end.to raise_exception(ArgumentError)


### PR DESCRIPTION
When exception is raised, the place to log error messages has lost the request context. This PR moves the log call within request context.