### PR TITLE
Rubocop update to 1.0.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -28,4 +28,4 @@ plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: "rubocop-0-69"
+    channel: rubocop-1-0

--- a/insights-api-common.gemspec
+++ b/insights-api-common.gemspec
@@ -38,6 +38,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake",        ">= 12.3.3"
+  spec.add_development_dependency "rubocop", "~> 1.0.0"
+  spec.add_development_dependency "rubocop-performance", "~>1.8"
+  spec.add_development_dependency "rubocop-rails", "~> 2.8"
   spec.add_development_dependency "rspec",       "~> 3.0"
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "rspec-rails", "~> 3.8"


### PR DESCRIPTION
Updating rubocop to 1.0.0 (also done for topological inventory + sources)

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)