### PR TITLE
Use custom error_message if a policy exposes it

### DIFF
--- a/lib/insights/api/common/custom_exceptions.rb
+++ b/lib/insights/api/common/custom_exceptions.rb
@@ -7,7 +7,8 @@ module Insights
         def self.custom_message(exception)
           case exception.class.to_s
           when "Pundit::NotAuthorizedError"
-            "You are not authorized to #{exception.query.to_s.delete_suffix('?')} this #{exception.record.model_name.human.downcase}"
+            exception.policy.try(:error_message) ||
+              "You are not authorized to perform the #{exception.query.to_s.delete_suffix('?')} action for this #{exception.record.model_name.human.downcase}"
           end
         end
       end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -88,11 +88,12 @@ end
 
 module Pundit
   class NotAuthorizedError < StandardError
-    attr_accessor :query, :record
+    attr_accessor :query, :record, :policy
 
-    def initialize(query, record)
+    def initialize(query, record, policy = nil)
       @query = query
       @record = record
+      @policy = policy
     end
   end
 end

--- a/spec/lib/insights/api/common/custom_exceptions_spec.rb
+++ b/spec/lib/insights/api/common/custom_exceptions_spec.rb
@@ -1,26 +1,41 @@
 describe Insights::API::Common::CustomExceptions do
   describe ".custom_message with Pundit::NotAuthorizedError exception" do
     let(:record) { SourceType.new }
-    let(:exception) { double(:class => "Pundit::NotAuthorizedError", :query => query, :record => record) }
+    let(:exception) { double(:class => "Pundit::NotAuthorizedError", :query => query, :record => record, :policy => policy) }
 
-    shared_examples_for "#test_message" do
+    context "when a custom error message exists on the policy" do
+      let(:query) { "create?" }
+      let(:policy) { double(:error_message => "This custom error message says 'no', you can't do that") }
+
       it "returns a customized message" do
         expect(Insights::API::Common::CustomExceptions.custom_message(exception)).to eq(
-          "You are not authorized to create this source type"
+          "This custom error message says 'no', you can't do that"
         )
       end
     end
 
-    context "when the query is String" do
-      let(:query) { "create?" }
+    context "when a custom error message does not exist on the policy" do
+      let(:policy) { nil }
 
-      it_behaves_like "#test_message"
-    end
+      shared_examples_for "#test_message" do
+        it "returns a customized message" do
+          expect(Insights::API::Common::CustomExceptions.custom_message(exception)).to eq(
+            "You are not authorized to perform the create action for this source type"
+          )
+        end
+      end
 
-    context "when the query is Symbol" do
-      let(:query) { :create? }
+      context "when the query is String" do
+        let(:query) { "create?" }
 
-      it_behaves_like "#test_message"
+        it_behaves_like "#test_message"
+      end
+
+      context "when the query is Symbol" do
+        let(:query) { :create? }
+
+        it_behaves_like "#test_message"
+      end
     end
   end
 end

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     it "returns a customized error message" do
       get("/api/v1.0/pundit_error", :headers => headers)
       expect(response.status).to eq(403)
-      expect(error.first["detail"]).to match(/You are not authorized to create this source type/)
+      expect(error.first["detail"]).to match(/You are not authorized to perform the create action for this source type/)
     end
   end
 


### PR DESCRIPTION
When we check requirements for actions, we generally check against the parent Portfolio if the user has the permission to update the Portfolio. This happens for example when creating portfolio items or when editing surveys, resetting service plans, and various other actions for portfolio items and service plans.

However, because we're checking against a Portfolio, the way Pundit handles it if the check fails is that the record stored in the exception is now `Portfolio`, which ends up generating bad messages because the user will see "You are not authorized to _action_ for this Portfolio" when they were trying to create/edit either a portfolio item or a service plan. There's not a really great way that I could find to directly override the `exception.record` without monkeypatching Pundit itself, and that felt pretty gross.

This change is very minimal to the common repo in favor of pushing the responsibility of setting a correct error message on the policy side. If the policy wishes to have a custom message, they simply set the instance variable in the method where they would like the custom message, and this should handle it. If not, we will default to the default message, although I did change the wording a little bit to better reflect the changes I made to the policy error messages.

For more info,
Please see the catalog-api PR here: https://github.com/RedHatInsights/catalog-api/pull/883
And the JIRA story here: https://issues.redhat.com/browse/SSP-1977

@lindgrenj6 Please review, or tag someone who you should think review. Thanks!