### PR TITLE
Release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2021-01-13
+### Changed
+- Make `Parameters#params_for_update` only include writeable fields in permit-hash #213
+- Use custom error_message if a policy exposes it #214
+
 ## [4.1.5] - 2020-10-01
 ### Changed
 - Fixed to log error messages in with_request block #208
@@ -198,7 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Initial release to rubygems.org
 
 
-[Unreleased]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.5...HEAD
+[Unreleased]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.5...v5.0.0
 [4.1.5]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.4...v4.1.5
 [4.1.4]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.3...v4.1.4
 [4.1.3]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.2...v4.1.3

--- a/lib/insights/api/common/version.rb
+++ b/lib/insights/api/common/version.rb
@@ -1,7 +1,7 @@
 module Insights
   module API
     module Common
-      VERSION = "4.1.5".freeze
+      VERSION = "5.0.0".freeze
     end
   end
 end


### PR DESCRIPTION
Debating naming this release `4.2.0` instead of `4.1.6` due to the fact that `params_for_update` behavior is changing. Theoretically it should be a bug fix, but the behavior is changing nonetheless.

EDIT: After talking with Drew we decided to release 5.0 instead of a minor release due to the fact this is a breaking change that could introduce small intricacies in catalog and other apps using this code. 

cc @hsong-rh @eclarizio @syncrou

*DEPENDS ON*: 
- [x] #213
- [x] #214
