### PR TITLE
Release 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1] - 2021-01-26
+### Changed
+- Pinning `graphql` gem to 1.11.7 due to breaking change in version 1.12.0
+
 ## [5.0.0] - 2021-01-13
 ### Changed
 - Make `Parameters#params_for_update` only include writeable fields in permit-hash #213
@@ -203,7 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Initial release to rubygems.org
 
 
-[Unreleased]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v5.0.0...HEAD
+[Unreleased]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v5.0.1...HEAD
+[5.0.1]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.5...v5.0.0
 [4.1.5]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.4...v4.1.5
 [4.1.4]: https://github.com/RedHatInsights/insights-api-common-rails/compare/v4.1.3...v4.1.4

--- a/insights-api-common.gemspec
+++ b/insights-api-common.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "openapi_parser",      "~> 0.10.0"
 
   spec.add_runtime_dependency "insights-rbac-api-client", "~> 1.0"
-  # For Insights::API::Common::GraphQL
-  spec.add_runtime_dependency "graphql",         "~> 1.9"
+  # For Insights::API::Common::GraphQL, pinning for now due to breaking change brought in 1.12.0
+  spec.add_runtime_dependency "graphql",         "1.11.7"
   spec.add_runtime_dependency "graphql-batch",   "~> 0.4"
   spec.add_runtime_dependency "graphql-preload", "~> 2.0", "< 2.1"
   spec.add_runtime_dependency "query_relation"

--- a/lib/insights/api/common/version.rb
+++ b/lib/insights/api/common/version.rb
@@ -1,7 +1,7 @@
 module Insights
   module API
     module Common
-      VERSION = "5.0.0".freeze
+      VERSION = "5.0.1".freeze
     end
   end
 end


### PR DESCRIPTION
The `graphql` gem introduced a breaking change recently, I found it locally today in sources-api during development and @mkanoor found it on Catalog side as well.

Pinning to 1.11.7 for now while we wait to get it fixed.
