### PR TITLE
Bind to 127.0.0.1 instead of localhost

### DIFF
--- a/lib/insights/api/common/metrics.rb
+++ b/lib/insights/api/common/metrics.rb
@@ -17,7 +17,7 @@ module Insights
 
         private_class_method def self.ensure_exporter_server
           require 'socket'
-          TCPSocket.open("localhost", metrics_port) {}
+          TCPSocket.open("127.0.0.1", metrics_port) {}
         rescue Errno::ECONNREFUSED
           require 'prometheus_exporter/server'
           server = PrometheusExporter::Server::WebServer.new(port: metrics_port)


### PR DESCRIPTION
When I tested clowder in minikube I got the problem that prometheus cannot bind to a port in localhost. The error message was `cannot assign requested address: localhost`. Changing to `127.0.0.1` solves the problem.