### PR TITLE
Allow to load GraphQL erb templates outside of repo

### DIFF
--- a/lib/insights/api/common/graphql/generator.rb
+++ b/lib/insights/api/common/graphql/generator.rb
@@ -20,8 +20,32 @@ module Insights
             openapi_path.split("/")[1..-1]
           end
 
+          def self.template_file_by(type, root_dir = __dir__)
+            Pathname.new(root_dir).join(File.expand_path("templates", root_dir), "#{type}.erb")
+          end
+
+          def self.root_dir
+            Rails.root
+          end
+
+          def self.app_name
+            Rails.application.class.parent.name.underscore
+          end
+
+          def self.pluggable_template_file_by(type)
+            templates_relative_path = "lib/#{app_name}/api/graphql/templates"
+            template_path = File.expand_path(templates_relative_path, root_dir)
+            Pathname.new(root_dir).join(template_path, "#{type}.erb")
+          end
+
+          def self.template_path_by(type)
+            template_path_pluggable = pluggable_template_file_by(type)
+            template_path_default   = template_file_by(type)
+            template_path_pluggable.exist? ? template_path_pluggable : template_path_default
+          end
+
           def self.template(type)
-            File.read(Pathname.new(__dir__).join(File.expand_path("templates", __dir__), "#{type}.erb").to_s)
+            File.read(template_path_by(type))
           end
 
           def self.graphql_type(property_name, property_format, property_type)

--- a/spec/lib/insights/api/common/graphql/generator_spec.rb
+++ b/spec/lib/insights/api/common/graphql/generator_spec.rb
@@ -71,59 +71,68 @@ RSpec.describe Insights::API::Common::GraphQL::Generator do
     let(:graphql_schema_pluggable_directory) { Pathname.new(graphql_schema_pluggable) }
     let(:schema_path)                        { graphql_schema_pluggable_directory.join("schema.erb") }
 
-    before do
-      ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0") if ::Insights::API::Common::GraphQL::Api.const_defined?("V2x0", false)
+    %i[enabled_introspection disabled_introspection].each do |introspection|
+      context "Introspection settings: #{introspection}" do
+        before do
+          ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0") if ::Insights::API::Common::GraphQL::Api.const_defined?("V2x0", false)
 
-      allow(described_class).to receive(:root_dir).and_return(root_dir)
-
-      FileUtils.mkpath(graphql_schema_pluggable_directory)
-      File.write(schema_path, graphql_schema)
-    end
-
-    after do
-      ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0")
-
-      FileUtils.rm_r(schema_path)
-    end
-
-    it "support base_query" do
-      graphql_request = double
-      allow(graphql_request).to receive(:original_url).and_return(graphql_endpoint_v2)
-
-      schema_overlay = {
-        "^source_types$" => {
-          "base_query" => lambda do |model_class, _args, _ctx|
-            model_class.where(:vendor => "redhat")
+          if introspection == :disabled_introspection
+            allow(described_class).to receive(:root_dir).and_return(root_dir)
+            FileUtils.mkpath(graphql_schema_pluggable_directory)
+            File.write(schema_path, graphql_schema)
           end
-        }
-      }
+        end
 
-      graphql_query = '
-        {
-          source_types(sort_by: { name: "asc" }) {
-            name
-            vendor
-          }
-        }
-      '
+        after do
+          ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0")
 
-      graphql_api_schema = described_class.init_schema_v2(graphql_request, schema_overlay)
-      expect(graphql_api_schema.disable_introspection_entry_points).to be_truthy
+          FileUtils.rm_r(schema_path) if introspection == :disabled_introspection
+        end
 
-      result = graphql_api_schema.execute(graphql_query, :variables => {})
-      expect(result["data"]).to eq(JSON.parse('
-        {
-          "source_types": [
-            {
-              "name": "openshift_test",
-              "vendor": "redhat"
-            },
-            {
-              "name": "rhev_test",
-              "vendor": "redhat"
+        it "support base_query" do
+          graphql_request = double
+          allow(graphql_request).to receive(:original_url).and_return(graphql_endpoint_v2)
+
+          schema_overlay = {
+            "^source_types$" => {
+              "base_query" => lambda do |model_class, _args, _ctx|
+                model_class.where(:vendor => "redhat")
+              end
             }
-          ]
-        }'))
+          }
+
+          graphql_query = '
+            {
+              source_types(sort_by: { name: "asc" }) {
+                name
+                vendor
+              }
+            }
+          '
+
+          graphql_api_schema = described_class.init_schema_v2(graphql_request, schema_overlay)
+          if introspection == :disabled_introspection
+            expect(graphql_api_schema.disable_introspection_entry_points).to be_truthy
+          else
+            expect(graphql_api_schema.disable_introspection_entry_points).to be_falsey
+          end
+
+          result = graphql_api_schema.execute(graphql_query, :variables => {})
+          expect(result["data"]).to eq(JSON.parse('
+            {
+              "source_types": [
+                {
+                  "name": "openshift_test",
+                  "vendor": "redhat"
+                },
+                {
+                  "name": "rhev_test",
+                  "vendor": "redhat"
+                }
+              ]
+            }'))
+        end
+      end
     end
   end
 end

--- a/spec/lib/insights/api/common/graphql/generator_spec.rb
+++ b/spec/lib/insights/api/common/graphql/generator_spec.rb
@@ -53,8 +53,38 @@ RSpec.describe Insights::API::Common::GraphQL::Generator do
   end
 
   context "schema overlays v2" do
-    before { ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0") if ::Insights::API::Common::GraphQL::Api.const_defined?("V2x0", false) }
-    after  { ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0") }
+    let(:graphql_schema) do
+      <<~RUBY
+        Schema = ::GraphQL::Schema.define do
+          use ::GraphQL::Batch
+          enable_preloading
+          disable_introspection_entry_points
+
+          query QueryType
+        end
+      RUBY
+    end
+
+    let(:application_name)                   { Rails.application.class.parent.name.underscore }
+    let(:root_dir)                           { Dir.mktmpdir("root_dir") }
+    let(:graphql_schema_pluggable)           { "#{root_dir}/lib/#{application_name}/api/graphql/templates" }
+    let(:graphql_schema_pluggable_directory) { Pathname.new(graphql_schema_pluggable) }
+    let(:schema_path)                        { graphql_schema_pluggable_directory.join("schema.erb") }
+
+    before do
+      ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0") if ::Insights::API::Common::GraphQL::Api.const_defined?("V2x0", false)
+
+      allow(described_class).to receive(:root_dir).and_return(root_dir)
+
+      FileUtils.mkpath(graphql_schema_pluggable_directory)
+      File.write(schema_path, graphql_schema)
+    end
+
+    after do
+      ::Insights::API::Common::GraphQL::Api.send(:remove_const, "V2x0")
+
+      FileUtils.rm_r(schema_path)
+    end
 
     it "support base_query" do
       graphql_request = double
@@ -78,8 +108,9 @@ RSpec.describe Insights::API::Common::GraphQL::Generator do
       '
 
       graphql_api_schema = described_class.init_schema_v2(graphql_request, schema_overlay)
-      result = graphql_api_schema.execute(graphql_query, :variables => {})
+      expect(graphql_api_schema.disable_introspection_entry_points).to be_truthy
 
+      result = graphql_api_schema.execute(graphql_query, :variables => {})
       expect(result["data"]).to eq(JSON.parse('
         {
           "source_types": [


### PR DESCRIPTION
This allows to make GraphQL erb([model_type.erb](https://github.com/RedHatInsights/insights-api-common-rails/blob/master/lib/insights/api/common/graphql/templates/model_type.erb), [query_type.erb](https://github.com/RedHatInsights/insights-api-common-rails/blob/master/lib/insights/api/common/graphql/templates/query_type.erb), [schema.erb](https://github.com/RedHatInsights/insights-api-common-rails/blob/master/lib/insights/api/common/graphql/templates/schema.erb)) templates configurable in repo(For example in sources-api) where is insights-api-common-rails gem used and 
templates live in location  `./api/common/graphql/templates` in remote repos.

Example: So if you want override GraphQL schema for source-api, you 
need to create file in source-api repo like is this [PR](https://github.com/RedHatInsights/sources-api/pull/348).


### Links
Together with [TOPO PR](https://github.com/RedHatInsights/topological_inventory-api/pull/350) and [Sources PR](https://github.com/RedHatInsights/sources-api/pull/348) fixes: https://issues.redhat.com/browse/RHCLOUD-11179 and disables GraphQL introspection  in source/topo  APIs.

