### PR TITLE
Use insights logger gem

### DIFF
--- a/insights-api-common.gemspec
+++ b/insights-api-common.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rails",             ">= 5.2.2.1", "~> 5.2.2"
 
   # For Insights::API::Common::Logging
-  spec.add_runtime_dependency "manageiq-loggers", "~> 0.3"
-  spec.add_runtime_dependency "cloudwatchlogger", "~> 0.2.1"
+  spec.add_runtime_dependency "insights-loggers-ruby", "~> 0.1.10"
 
   # For Insights::API::Common::Metrics
   spec.add_runtime_dependency "prometheus_exporter", "~> 0.4.5"

--- a/lib/insights/api/common/logging.rb
+++ b/lib/insights/api/common/logging.rb
@@ -2,14 +2,27 @@ module Insights
   module API
     module Common
       class Logging
-        def self.activate(config)
-          require 'manageiq/loggers'
-          config.logger = if Rails.env.production?
-                            config.colorize_logging = false
-                            ManageIQ::Loggers::CloudWatch.new
-                          else
-                            ManageIQ::Loggers::Base.new(Rails.root.join("log", "#{Rails.env}.log"))
-                          end
+        def self.logger_class
+          if ENV['LOG_HANDLER'] == "haberdasher"
+            "Insights::Loggers::StdErrorLogger"
+          else
+            "Insights::Loggers::CloudWatch"
+          end
+        end
+
+        def self.activate(config, app_name = nil)
+          require 'insights/loggers'
+          log_params = {}
+          klass_for_logger = if Rails.env.production?
+                               config.colorize_logging = false
+                               log_params[:app_name] = app_name if app_name
+                               logger_class
+                             else
+                               log_params = {:log_path => Rails.root.join("log", "#{Rails.env}.log")}
+                               "ManageIQ::Loggers::Base"
+                             end
+
+          config.logger = Insights::Loggers::Factory.create_logger(klass_for_logger, log_params)
         end
       end
     end

--- a/spec/lib/insights/api/common/logging_spec.rb
+++ b/spec/lib/insights/api/common/logging_spec.rb
@@ -1,0 +1,52 @@
+require 'cloudwatchlogger'
+
+describe Insights::API::Common::Metrics do
+  let(:rails_config) { Rails.application.config }
+
+  subject { Insights::API::Common::Logging.activate(rails_config) }
+
+  context "development environment" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+    end
+
+    it "return proper logger class" do
+      expect(subject.class).to eq(ManageIQ::Loggers::Base)
+    end
+
+    context "haberdasher is set as log_handler" do
+      before do
+        ENV['LOG_HANDLER'] == "haberdasher"
+      end
+
+      it "return proper logger class" do
+        expect(subject.class).to eq(ManageIQ::Loggers::Base)
+      end
+    end
+  end
+
+  context "production environment" do
+    before do
+      ENV["CW_AWS_ACCESS_KEY_ID"] = "test"
+      ENV["CW_AWS_SECRET_ACCESS_KEY"] = "test"
+      ENV["CLOUD_WATCH_LOG_GROUP"] = "test"
+      ENV["HOSTNAME"] = "test"
+      allow(CloudWatchLogger::Client::AWS_SDK::DeliveryThreadManager).to receive(:new)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+    end
+
+    it "return proper logger class" do
+      expect(subject.class).to eq(Insights::Loggers::CloudWatch)
+    end
+
+    context "haberdasher is set as log_handler" do
+      before do
+        ENV['LOG_HANDLER'] = "haberdasher"
+      end
+
+      it "return proper logger class" do
+        expect(subject.class).to eq(Insights::Loggers::StdErrorLogger)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR replaces `manageiq-loggers` gem with [insights-loggers-ruby](https://github.com/RedHatInsights/insights-loggers-ruby) gem.

Usage is proper in rails applications:

```ruby
app_name = "sources-api"
Insights::API::Common::Logging.activate(config, app_name)
```

1. 
This changes allows to support haberdasher and in order to use haberdasher, `LOG_HANDLER ` environment variable needs to be set:
```ruby
ENV['LOG_HANDLER'] = 'haberdasher'
```
`app_name` - optional parameter to set app_name - which is need for identification of source log message and it will be visible in `tags` and `labels`.

2.
Uses logger `Insights::Loggers::CloudWatch` instead of `ManageIQ::Loggers::CloudWatch`.
 `Insights::Loggers::CloudWatch` we can control log levels:
- container logger by `ENV['CONTAINER_LOG_LEVEL']`
-  CloudWatch  logger by `ENV['LOG_LEVEL']`

### Links
https://issues.redhat.com/browse/RHCLOUD-13925
