### PR TITLE
Ensure UTF-8 compatibility for ErrorDocument#to_h.to_json

### DIFF
--- a/lib/insights/api/common/error_document.rb
+++ b/lib/insights/api/common/error_document.rb
@@ -4,7 +4,8 @@ module Insights
       class ErrorDocument
         def add(status = 400, message)
           @status = status
-          errors << {"status" => status, "detail" => message}
+          safe_message = message.to_s.encode('UTF-8', :invalid => :replace, :undef => :replace)
+          errors << {"status" => status, "detail" => safe_message}
           self
         end
 

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -67,6 +67,10 @@ module Api
         raise SomethingHappened, "something else happened"
       end
 
+      def error_utf8
+        raise StandardError, "something \xAE happened"
+      end
+
       def http_error
         raise ActionCable::Connection::Authorization::UnauthorizedError
       end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     namespace :v1x0, :path => "v1.0" do
       get "/error",        :to => "errors#error"
       get "/error_nested", :to => "errors#error_nested"
+      get "/error_utf8",   :to => "errors#error_utf8"
       get "/http_error", :to => "errors#http_error"
       get "/api_client_error", :to => "errors#api_client_error"
       get "/pundit_error", :to => "errors#pundit_error"

--- a/spec/requests/exception_handling_spec.rb
+++ b/spec/requests/exception_handling_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe "Insights::API::Common::ApplicationController Exception Handling"
     end
   end
 
+  context "utf-8 conversion error" do
+    it "returns the error message" do
+      get "/api/v1.0/error_utf8", :headers => headers
+      expect(response.status).to eq(400)
+      expect(error.first["detail"]).to match(/StandardError/)
+    end
+  end
+
   context "api_client_error" do
     context "with response body" do
       let(:response_header) { { 'Content-Type' => 'application/json' } }


### PR DESCRIPTION
Sources API on CI produces: 
```
{"@timestamp":"2021-05-24T10:42:31.871175 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"info","message":"Started GET \"/api/sources/v3.1/application_types/2/sources?filter%5Bid%5D=25613\" for 10.129.13.104 at 2021-05-24 10:42:31 +0000"}
--
{"@timestamp":"2021-05-24T10:42:31.872593 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"info","message":"Completed 500 Internal Server Error in 1ms (ActiveRecord: 0.0ms)"}
{"@timestamp":"2021-05-24T10:42:31.873434 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"crit","message":"  "}
{"@timestamp":"2021-05-24T10:42:31.873520 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"crit","message":"JSON::GeneratorError (source sequence is illegal/malformed utf-8):"}
{"@timestamp":"2021-05-24T10:42:31.874322 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"crit","message":"  "}
{"@timestamp":"2021-05-24T10:42:31.874501 ","hostname":"sources-api-1210-qlghn","pid":30,"tid":"2b04d7eb3334","level":"crit","message":"activesupport (5.2.6) lib/active_support/core_ext/object/json.rb:38:in `to_json'\nactivesupport (5.2.6) lib/active_support/core_ext/object/json.rb:38:in `to_json'\nactivesupport (5.2.6) lib/active_support/json/encoding.rb:57:in `to_json'\njson (2.5.1) lib/json/common.rb:312:in `generate'\njson (2.5.1) lib/json/common.rb:312:in `generate'\nactivesupport (5.2.6) lib/active_support/json/encoding.rb:102:in `stringify'\nactivesupport (5.2.6) lib/active_support/json/encoding.rb:35:in `encode'\nactivesupport (5.2.6) lib/active_support/json/encoding.rb:22:in `encode'\nactivesupport (5.2.6) lib/active_support/core_ext/object/json.rb:41:in `to_json'\nactionpack (5.2.6) lib/action_controller/metal/renderers.rb:157:in `block in &lt;module:Renderers&gt;'\nactionpack (5.2.6) lib/action_controller/metal/renderers.rb:150:in `block in _render_to_body_with_renderer'\n/usr/share/ruby/set.rb:338:in `each_key'\n/usr/share/ruby/set.rb:338:in `each'\nactionpack (5.2.6) lib/action_controller/metal/renderers.rb:146:in `_render_to_body_with_renderer'\nactionpack (5.2.6) lib/action_controller/metal/renderers.rb:142:in `render_to_body'\nactionpack (5.2.6) lib/abstract_controller/rendering.rb:25:in `render'\nactionpack (5.2.6) lib/action_controller/metal/rendering.rb:36:in `render'\nactionpack (5.2.6) lib/action_controller/metal/instrumentation.rb:46:in `block (2 levels) in render'\nactivesupport (5.2.6) lib/active_support/core_ext/benchmark.rb:14:in `block in ms'\n/usr/share/ruby/benchmark.rb:308:in `realtime'\nactivesupport (5.2.6) lib/active_support/core_ext/benchmark.rb:14:in `ms'\nactionpack (5.2.6) lib/action_controller/metal/instrumentation.rb:46:in `block in render'\nactionpack (5.2.6) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'\nactiverecord (5.2.6) lib/active_record/railties/controller_runtime.rb:36:in `cleanup_view_runtime'\nactionpack (5.2.6) lib/action_controller/metal/instrumentation.rb:45:in `render'\n
insights-api-common (5.0.2) lib/insights/api/common/application_controller_mixins/exception_handling.rb:30:in `rescue_from_handler'
insights-api-common (5.0.2) lib/insights/api/common/application_controller_mixins/exception_handling.rb:10:in `block in included'
```

It can be caused by illegal characters in the `ErrorDocument` details

----

Error happens when `document.to_h` looks like this:

`{"errors" => [{"status" => 500, "detail" => "\xAE"}]}.to_json`

Not sure how to reproduce in real environment

---

[RHCLOUD-14351](https://issues.redhat.com/browse/RHCLOUD-14351)