### PR TITLE
Support total counts for GraphQL

### DIFF
--- a/lib/insights/api/common/filter.rb
+++ b/lib/insights/api/common/filter.rb
@@ -177,6 +177,20 @@ module Insights
           end
         end
 
+        def self.build_filtered_scope(scope, api_version, klass_name, filter)
+          return scope unless filter
+
+          openapi_doc = ::Insights::API::Common::OpenApi::Docs.instance[api_version]
+          openapi_schema_name, = ::Insights::API::Common::GraphQL::Generator.openapi_schema(openapi_doc, klass_name)
+
+          action_parameters = ActionController::Parameters.new(filter)
+          definitions = openapi_doc.definitions
+
+          association_attribute_properties = association_attribute_properties(definitions, action_parameters)
+
+          new(scope, action_parameters, definitions[openapi_schema_name], association_attribute_properties).apply
+        end
+
         def timestamp(k, val)
           if val.kind_of?(Hash)
             val.each do |comparator, value|

--- a/lib/insights/api/common/graphql/generator.rb
+++ b/lib/insights/api/common/graphql/generator.rb
@@ -165,8 +165,10 @@ module Insights
               graphql_model_type_template = ERB.new(template("model_type"), nil, '<>').result(binding)
               graphql_namespace.module_eval(graphql_model_type_template)
 
-              graphql_aggregate_model_type_template = ERB.new(template("aggregate_model_type"), nil, '<>').result(binding)
-              graphql_namespace.module_eval(graphql_aggregate_model_type_template)
+              unless graphql_namespace.const_defined?("#{klass_name}AggregateType", false)
+                graphql_aggregate_model_type_template = ERB.new(template("aggregate_model_type"), nil, '<>').result(binding)
+                graphql_namespace.module_eval(graphql_aggregate_model_type_template)
+              end
             end
 
             graphql_aggregate_type_template = ERB.new(template("aggregate_type"), nil, '<>').result(binding)

--- a/lib/insights/api/common/graphql/generator.rb
+++ b/lib/insights/api/common/graphql/generator.rb
@@ -164,7 +164,13 @@ module Insights
 
               graphql_model_type_template = ERB.new(template("model_type"), nil, '<>').result(binding)
               graphql_namespace.module_eval(graphql_model_type_template)
+
+              graphql_aggregate_model_type_template = ERB.new(template("aggregate_model_type"), nil, '<>').result(binding)
+              graphql_namespace.module_eval(graphql_aggregate_model_type_template)
             end
+
+            graphql_aggregate_type_template = ERB.new(template("aggregate_type"), nil, '<>').result(binding)
+            graphql_namespace.module_eval(graphql_aggregate_type_template)
 
             graphql_query_type_template = ERB.new(template("query_type"), nil, '<>').result(binding)
             graphql_namespace.module_eval(graphql_query_type_template)

--- a/lib/insights/api/common/graphql/templates/aggregate_model_type.erb
+++ b/lib/insights/api/common/graphql/templates/aggregate_model_type.erb
@@ -1,0 +1,8 @@
+<%= klass_name %>AggregateType = ::GraphQL::ObjectType.define do
+  name "<%= klass_name %>AggregateType"
+  description "A <%= klass_name %>AggregateType to wrap metrics aggregation"
+
+  field :aggregate, AggregateType do
+    resolve ->(object, _args, _ctx) { object }
+  end
+end

--- a/lib/insights/api/common/graphql/templates/aggregate_type.erb
+++ b/lib/insights/api/common/graphql/templates/aggregate_type.erb
@@ -1,0 +1,14 @@
+AggregateType = ::GraphQL::ObjectType.define do
+  name "AggregateType"
+  description "A AggregateType type for aggregation metrics"
+
+  field :total_count, !types.Int do
+    resolve ->(object, _args, _ctx) {
+      if object.kind_of?(QueryRelation) # from nested aggregation
+        object.count # count is array operation
+      else
+        object
+      end
+    }
+  end
+end

--- a/lib/insights/api/common/graphql/templates/model_type.erb
+++ b/lib/insights/api/common/graphql/templates/model_type.erb
@@ -30,6 +30,19 @@
       ::Insights::API::Common::GraphQL::AssociationLoader.new(<%= klass_name.constantize %>, "<%= associations %>", args, graphql_options).load(obj)
     }
   end
+
+  field :<%= associations %>_aggregate do
+    description "Aggregation of <%= associations %> associated with <%= klass_name %> model."
+    type <%= "#{association_class_name}AggregateType" %>
+
+    associations_name = "<%= associations %>"
+    preload :<%= associations %>
+
+    resolve lambda { |obj, args, _ctx|
+      ::Insights::API::Common::GraphQL::AssociationLoader.new(<%= klass_name.constantize %>, "<%= associations %>", args, graphql_options).load(obj)
+    }
+  end
+
 <%   end %>
 <% end %>
 end

--- a/lib/insights/api/common/graphql/templates/query_type.erb
+++ b/lib/insights/api/common/graphql/templates/query_type.erb
@@ -45,5 +45,24 @@ QueryType = ::GraphQL::ObjectType.define do
         end
       }
     end
+
+    field_aggregate = "#{collection}_aggregate"
+    field field_aggregate do
+      description "The #{collection} aggregation associated with this #{klass_name}"
+      klass_name_type = "::Insights::API::Common::GraphQL::Api::#{version_namespace}::#{klass_name}AggregateType".constantize
+      argument :filter, ::Insights::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
+
+      type klass_name_type
+
+      resolve lambda { |_obj, args, _ctx|
+        if base_query.present?
+          scope = base_query.call(model_class, args, ctx)
+        else
+          scope = model_class
+        end
+
+        ::Insights::API::Common::Filter.build_filtered_scope(scope, "<%= api_version %>", klass_name, args[:filter]).count
+      }
+    end
   end
 end

--- a/lib/insights/api/common/graphql/templates/query_type.erb
+++ b/lib/insights/api/common/graphql/templates/query_type.erb
@@ -31,18 +31,9 @@ QueryType = ::GraphQL::ObjectType.define do
           scope = model_class
         end
 
-        if args[:filter]
-          openapi_doc = ::Insights::API::Common::OpenApi::Docs.instance["<%= api_version %>"]
-          openapi_schema_name, _schema = ::Insights::API::Common::GraphQL::Generator.openapi_schema(openapi_doc, klass_name)
-          association_attribute_properties =
-            Insights::API::Common::Filter.association_attribute_properties(openapi_doc.definitions, ActionController::Parameters.new(args[:filter]))
-          scope = ::Insights::API::Common::Filter.new(
-            scope,
-            ActionController::Parameters.new(args[:filter]),
-            openapi_doc.definitions[openapi_schema_name],
-            association_attribute_properties).apply
-        end
+        scope = ::Insights::API::Common::Filter.build_filtered_scope(scope, "<%= api_version %>", klass_name, args[:filter])
         scope = ::Insights::API::Common::GraphQL.search_options(scope, args)
+
         if <%= graphql_options[:use_pagination_v2] %> == true
           ::Insights::API::Common::PaginatedResponseV2.new(
             base_query: scope, request: nil, limit: args[:limit], offset: args[:offset], sort_by: args[:sort_by]


### PR DESCRIPTION
This PR adds to possibility to query aggregate metric `total_count`:
```
sources_aggregate(filter: { source_type: { vendor: { not_eq: "Red Hat"} } })
{
   aggregate
   {
     total_count 
   }
}
```

To query  `total_count` for `collection`: 
```
<collection>_aggregate
{
   aggregate
   {
      total_count 
   }
}
```
also with filtering as on collection:

```
<collection>_aggregate(filter: { source_type: { vendor: { not_eq: "Red Hat"} } })
{
     aggregate
     {
	 total_count 
     }
}
```

Total count can be obtain without limits, offset but with filtering which was intended.

This aggregation can be also on nested associations(NOTE: There is no filtering on nested associations implemented, only limit, offset so filtering is not also present on nested aggregation):

```
query{
  sources(limit:2, offset:0, sort_by:{created_at: "desc"}, 
  filter: { source_type: { vendor: { not_eq: "Red Hat"} } })        
  {   
    name,
    id,    
    created_at,    
    source_type_id,
    applications {
      id
    },
    authentications{
      id
    },
    authentications_aggregate{
       total_count 
    }
  }
}
```
## Examples
With nested associations
**query**:
```
 {
    source_types(limit:2, offset: 0,filter: {vendor: {not_eq: "redhat"}}) {
      vendor
      product_name
      sources {
        name
        endpoints {
          host
          port
          role
          authentications {
            authtype
            username
          }
          authentications_aggregate {
            aggregate{
              total_count
            }
          }
        },
        endpoints_aggregate {
          aggregate{
            total_count
          }
        }
      },
      sources_aggregate {
        aggregate{
          total_count
        }
      }
    },
    source_types_aggregate(filter: {vendor: {not_eq: "redhat"}})
    {
      aggregate{
        total_count
      }
      
    }
  }
```
**response**
```
{
  "data": {
    "source_types": [
      {
        "vendor": "Amazon",
        "product_name": "Amazon Web Services",
        "sources": [
          {
            "name": "Amazon Source",
            "endpoints": [
              {
                "host": null,
                "port": null,
                "role": null,
                "authentications": [
                  {
                    "authtype": "access_key_secret_key",
                    "username": "XXX"
                  }
                ],
                "authentications_aggregate": {
                  "aggregate": {
                    "total_count": 1
                  }
                }
              }
            ],
            "endpoints_aggregate": {
              "aggregate": {
                "total_count": 1
              }
            }
          }
        ],
        "sources_aggregate": {
          "aggregate": {
            "total_count": 1
          }
        }
      },
      {
        "vendor": "Red Hat",
        "product_name": "Red Hat Ansible Automation Platform",
        "sources": [
          {
            "name": "Ansible Tower Source",
            "endpoints": [
              {
                "host": "tower.example.com",
                "port": null,
                "role": "ansible",
                "authentications": [
                  {
                    "authtype": "username_password",
                    "username": "XXX"
                  }
                ],
                "authentications_aggregate": {
                  "aggregate": {
                    "total_count": 1
                  }
                }
              }
            ],
            "endpoints_aggregate": {
              "aggregate": {
                "total_count": 1
              }
            }
          }
        ],
        "sources_aggregate": {
          "aggregate": {
            "total_count": 1
          }
        }
      }
    ],
    "source_types_aggregate": {
      "aggregate": {
        "total_count": 7
      }
    }
  }
}
```

### Perfomance implications
**Querying aggregation at top level:**
```
{
  sources        
  {   
      name,
  },
  sources_aggregate(
  {
    aggregate{
      total_count 
    }
  }
}
```
This executes 2 queries  one for collection and one for counts. PostgreSQL provides windows to query total count without using limit, offset - but there is drawback: `offset` has to be greater than total count. Other solution is do complex query.
So I left  2 queries as it looks that it is enough  - and we should take into account mentioned alternative only for lot of rows.

**Querying aggregation on nested association:**
Total counts are obtain by count on array as those associations are loaded - no extra sql queries.

cc @rvsia @syncrou @slemrmartin @lindgrenj6 

### Links
https://issues.redhat.com/browse/RHCLOUD-9332

